### PR TITLE
FC-23 Use SQS visibility timeout of 5 minutes instead of 30 seconds

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/manager/AwsMessagingInfrastructureManager.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/manager/AwsMessagingInfrastructureManager.java
@@ -41,15 +41,15 @@ import com.clicktravel.infrastructure.messaging.aws.SqsMessageQueueAccessor;
  * Amazon Web Services Messaging Infrastructure Manager
  * 
  * The responsibility of implementing classes is to create queues and topics, fetch queue and topic-related information
- * @author bjanjua
- * 
  */
 public class AwsMessagingInfrastructureManager {
 
     private static final String AWS_POLICY_ATTRIBUTE = "Policy";
     private static final String SQS_QUEUE_ARN_ATTRIBUTE = "QueueArn";
+    private static final String SQS_VISIBILITY_TIMEOUT_ATTRIBUTE = "VisibilityTimeout";
+    private static final String SQS_VISIBILITY_TIMEOUT_VALUE = "300";
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final AmazonSQS amazonSqsClient;
     private final AmazonSNS amazonSnsClient;
     private final Collection<SqsMessageQueueAccessor> messageQueueAccessors;
@@ -202,7 +202,9 @@ public class AwsMessagingInfrastructureManager {
 
     public void createQueue(final String queueName) {
         logger.debug("Creating queue: " + queueName);
-        final CreateQueueRequest createQueueRequest = new CreateQueueRequest(queueName);
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(SQS_VISIBILITY_TIMEOUT_ATTRIBUTE, SQS_VISIBILITY_TIMEOUT_VALUE);
+        final CreateQueueRequest createQueueRequest = new CreateQueueRequest(queueName).withAttributes(attributes);
         amazonSqsClient.createQueue(createQueueRequest);
     }
 

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/messaging/aws/manager/AwsMessagingInfrastructureManagerTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/messaging/aws/manager/AwsMessagingInfrastructureManagerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -122,7 +123,12 @@ public class AwsMessagingInfrastructureManagerTest {
         final ArgumentCaptor<CreateQueueRequest> createQueueRequestArgumentCaptor = ArgumentCaptor
                 .forClass(CreateQueueRequest.class);
         verify(mockAmazonSqsClient).createQueue(createQueueRequestArgumentCaptor.capture());
-        assertEquals(queueName, createQueueRequestArgumentCaptor.getValue().getQueueName());
+        final CreateQueueRequest createQueueRequest = createQueueRequestArgumentCaptor.getValue();
+        assertEquals(queueName, createQueueRequest.getQueueName());
+        final Map<String, String> queueAttributes = createQueueRequest.getAttributes();
+        assertNotNull(queueAttributes);
+        final String visibility = queueAttributes.get("VisibilityTimeout");
+        assertEquals("300", visibility);
     }
 
     @Test

--- a/cheddar/cheddar-remote/src/main/java/com/clicktravel/cheddar/infrastructure/remote/RemotingGateway.java
+++ b/cheddar/cheddar-remote/src/main/java/com/clicktravel/cheddar/infrastructure/remote/RemotingGateway.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class RemotingGateway {
     private static final long MAX_QUEUE_OFFER_TIMEOUT_SECONDS = 1; // Max wait for threads to synchronise
-    private static final long MAX_QUEUE_POLL_TIMEOUT_SECONDS = 40; // Must cover all remote method call retries
+    private static final long MAX_QUEUE_POLL_TIMEOUT_SECONDS = 310; // Must cover all remote method call retries
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final RemoteCallSender remoteCallSender;
 


### PR DESCRIPTION
SQS queues are created such that messages have a visibility timeout of 5 minutes. This gives message handlers up to 5 minutes to process each message, instead of the default 30 seconds. Existing queues are not affected.

Signed-off-by: Steffan Westcott steffan.westcott@clicktravel.com
