### PR TITLE
Fix temporary solution for handling foreign SQS messages

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/SqsMessageProcessor.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/SqsMessageProcessor.java
@@ -110,10 +110,10 @@ public class SqsMessageProcessor implements Runnable {
         Message message;
         MessageHandler messageHandler;
         // TODO Replace the following hack to generalise message listener to handle any message, including foreign ones
-        if (messageHandlers.containsKey(null)) {
+        if (messageHandlers.containsKey("")) {
             // Handle foreign message
-            message = new SimpleMessage(null, sqsMessage.getBody());
-            messageHandler = messageHandlers.get(null);
+            message = new SimpleMessage("", sqsMessage.getBody());
+            messageHandler = messageHandlers.get("");
         } else {
             // Handle native Cheddar message
             message = getMessage(sqsMessage);


### PR DESCRIPTION
To allow handling of foreign SQS messages (not produced by Cheddar) add a single handler for messages of type "" (empty string). This is a temporary solution; the message listener will be generalised at a later time to better decouple message listening and handling.

Signed-off-by: Steffan Westcott steffan.westcott@clicktravel.com
