### PR TITLE
Language and encoding support for httpclient

### DIFF
--- a/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/HttpClient.java
+++ b/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/HttpClient.java
@@ -28,7 +28,10 @@ import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.RedirectionException;
 import javax.ws.rs.client.*;
-import javax.ws.rs.core.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -225,6 +228,18 @@ public class HttpClient {
     }
 
     /**
+     * Convenience method to get hold of the client directly allowing you to call more complex methods on the client
+     * such as a post entity with variant language headers
+     * 
+     * @param path The path to which the request needs to be made, required
+     * @param params The query parameters appended to the path, required but can be empty
+     * @return
+     */
+    public Invocation.Builder getHttpClientBuilder(final String path, final MultivaluedHashMap<String, String> params) {
+        return requestBuilder(path, params);
+    }
+
+    /**
      * Convenience method to make HTTP GET request to a given URL without specifying any query parameters.
      * 
      * @see #get(String, Map)
@@ -245,33 +260,6 @@ public class HttpClient {
      */
     public Response get(final String path, final MultivaluedHashMap<String, String> params) {
         final Response response = requestBuilder(path, params).accept(accept).get();
-        return response;
-    }
-
-    /**
-     * Convenience method to make HTTP GET request to a given URL without specifying any query parameters in a given
-     * language
-     * 
-     * @see #get(String, Map)
-     * 
-     * @param path The path to which the GET request needs to be made
-     * @param acceptLanguage The language that you the request should be made with
-     * @return The HTTP response which is returned as a result of the GET request
-     */
-    public Response get(final String path, final String acceptLanguage) {
-        final Response response = get(path, new MultivaluedHashMap<String, String>(), acceptLanguage);
-        return response;
-    }
-
-    /**
-     * Makes a HTTP GET request to a given URL in a given language
-     * 
-     * @param path The path to which the GET request needs to be made
-     * @param acceptLanguage The language that you the request should be made with
-     * @return The HTTP response which is returned as a result of the GET request
-     */
-    public Response get(final String path, final MultivaluedHashMap<String, String> params, final String acceptLanguage) {
-        final Response response = requestBuilder(path, params).accept(accept).acceptLanguage(acceptLanguage).get();
         return response;
     }
 
@@ -331,42 +319,6 @@ public class HttpClient {
     }
 
     /**
-     * Makes HTTP POST request with a specified entity in the given language and with the given content type
-     * 
-     * @see #put(String, Object, MediaType)
-     * 
-     * @param path The path to which the request should be made
-     * @param entity The entity which is to be POSTed
-     * @param contentType The content type of the entity to be POSTed
-     * @param contentLanguage The content language of the entity to be POSTed
-     * @param contentEncoding The content encoding of the entity to be POSTed
-     * @return The HTTP response which is returned as a result of the POST request
-     */
-    public Response post(final String path, final Object entity, final MediaType contentType,
-            final String contentLanguage, final String contentEncoding) {
-        return post(path, new MultivaluedHashMap<String, String>(), entity, contentType, contentLanguage,
-                contentEncoding);
-    }
-
-    /**
-     * Makes HTTP POST request with a specified entity in the given language and with the given content type
-     * 
-     * @param path The path to which the request should be made
-     * @param params The query parameters appended to the path
-     * @param entity The entity which is to be POSTed
-     * @param contentType The content type of the entity to be POSTed
-     * @param contentLanguage The content language of the entity to be POSTed
-     * @param contentEncoding The content encoding of the entity to be POSTed
-     * @return The HTTP response which is returned as a result of the POST request
-     */
-    public Response post(final String path, final MultivaluedHashMap<String, String> params, final Object entity,
-            final MediaType contentType, final String contentLanguage, final String contentEncoding) {
-        final Response response = requestBuilder(path, params).post(
-                Entity.entity(entity, new Variant(contentType, contentLanguage, contentEncoding)));
-        return response;
-    }
-
-    /**
      * Makes HTTP PUT request with a specified entity
      * 
      * @see post(String, Object, MediaType)
@@ -379,25 +331,6 @@ public class HttpClient {
     public Response put(final String path, final Object entity, final MediaType contentType) {
         final Response response = requestBuilder(path, new MultivaluedHashMap<String, String>()).put(
                 Entity.entity(entity, contentType));
-        return response;
-    }
-
-    /**
-     * Makes HTTP PUT request with a specified entity in the given language and with the given content type
-     * 
-     * @see post(String, Object, MediaType)
-     * 
-     * @param path The path to which the request should be made
-     * @param entity The entity which is to be PUT
-     * @param contentType The content type of the entity to be PUT
-     * @param contentLanguage The content language of the entity to be PUT
-     * @param contentEncoding The content encoding of the entity to be PUT
-     * @return The HTTP response which is returned as a result of the PUT request
-     */
-    public Response put(final String path, final Object entity, final MediaType contentType,
-            final String contentLanguage, final String contentEncoding) {
-        final Response response = requestBuilder(path, new MultivaluedHashMap<String, String>()).put(
-                Entity.entity(entity, new Variant(contentType, contentLanguage, contentEncoding)));
         return response;
     }
 


### PR DESCRIPTION
From the jersey docs

Any variant-related HTTP headers previously set (namely {@code Content-Type},
     \*                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
     \*                     the entity variant information.

As such this adds support for making posts etc with variant information such as language. No changes made to existing methods just new methods added for the variant support

Signed-off-by: Robin Smith robin.smith@clicktravel.com
