### PR TITLE
[CHEDDAR] Improvements to HttpClient to enable Oauth 2.0 grant flow closer to the RFC

### DIFF
--- a/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/HttpClient.java
+++ b/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/HttpClient.java
@@ -16,6 +16,8 @@
  */
 package com.clicktravel.common.http.client;
 
+import static com.clicktravel.common.random.Randoms.randomId;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +32,6 @@ import javax.ws.rs.RedirectionException;
 import javax.ws.rs.client.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.client.ClientConfig;
@@ -39,8 +40,9 @@ import org.glassfish.jersey.client.ClientResponse;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.client.oauth2.OAuth2ClientSupport;
 import org.glassfish.jersey.client.oauth2.OAuth2CodeGrantFlow;
+import org.glassfish.jersey.client.oauth2.OAuth2CodeGrantFlow.Phase;
+import org.glassfish.jersey.client.oauth2.OAuth2Parameters;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
-import org.glassfish.jersey.uri.UriComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,21 +129,27 @@ public class HttpClient {
 
     private WebTarget getOAuthAuthenticatedTarget(final String baseUri, final OAuthConfiguration oauthConfiguration)
             throws AuthenticationException {
-        final Client client = ClientBuilder.newBuilder().withConfig(clientConfig()).build();
+        final Client client = buildIgnoreSslErrorClient(ClientBuilder.newBuilder().withConfig(clientConfig())).build();
+        final String state = randomId();
         final OAuth2CodeGrantFlow oauth2GrantFlow = OAuth2ClientSupport
                 .authorizationCodeGrantFlowBuilder(oauthConfiguration.clientIdentifier(),
                         oauthConfiguration.authorisationUri(), oauthConfiguration.accessTokenUri()).client(client)
-                .redirectUri(oauthConfiguration.redirectUri()).refreshTokenUri(oauthConfiguration.refreshTokenUri())
-                .build();
+                .redirectUri(oauthConfiguration.redirectUri()).scope("Default")
+                .refreshTokenUri(oauthConfiguration.refreshTokenUri())
+                .property(Phase.ALL, OAuth2Parameters.STATE, state).build();
 
         final String oauthRedirectUrl = oauth2GrantFlow.start();
-        final MultivaluedMap<String, String> receivedRedirectQueryParams = UriComponent.decodeQuery(oauthRedirectUrl,
-                true);
-        final String stateValue = receivedRedirectQueryParams.get("state").get(0);
 
-        final String authCode = oauthConfiguration.oauthUserAgent().authenticate();
+        logger.debug("The oauth redirect uri is: " + oauthRedirectUrl);
 
-        oauth2GrantFlow.finish(authCode, stateValue);
+        URI authenticationServerUri = null;
+        final Response response = client.target(oauthRedirectUrl).request().get();
+        logger.debug("The response for get was : " + response.getStatus());
+        authenticationServerUri = response.getLocation();
+
+        final String authCode = oauthConfiguration.oauthUserAgent().authenticate(authenticationServerUri);
+
+        oauth2GrantFlow.finish(authCode, state);
         return oauth2GrantFlow.getAuthorizedClient().target(baseUri);
     }
 

--- a/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/authentication/oauth2/OAuthUserAgent.java
+++ b/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/authentication/oauth2/OAuthUserAgent.java
@@ -16,6 +16,8 @@
  */
 package com.clicktravel.common.http.client.authentication.oauth2;
 
+import java.net.URI;
+
 import com.clicktravel.common.http.client.authentication.AuthenticationException;
 
 /**
@@ -40,6 +42,6 @@ public interface OAuthUserAgent {
      *         credentials.
      * @throws AuthenticationException
      */
-    String authenticate() throws AuthenticationException;
+    String authenticate(URI authenticationServerUri) throws AuthenticationException;
 
 }


### PR DESCRIPTION
- HttpClient has been improved to now request the address of the authentication server from the authorisation service correctly complying with steps taken in a successful the grant flow authentication.
- OAuthUserAgent interface has been updated to take the redirect uri of the authentication server.
