### PR TITLE
Add service test method for published events

### DIFF
--- a/cheddar/cheddar-integration-mocks/src/test/java/com/clicktravel/infrastructure/messaging/inmemory/StubOtherEvent.java
+++ b/cheddar/cheddar-integration-mocks/src/test/java/com/clicktravel/infrastructure/messaging/inmemory/StubOtherEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.infrastructure.messaging.inmemory;
+
+import com.clicktravel.cheddar.event.AbstractEvent;
+
+public class StubOtherEvent extends AbstractEvent {
+
+    public static final String type = "test.StubOtherEvent";
+
+    @Override
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
@@ -55,6 +55,7 @@ public class RestApplication {
             logger.info("Java process starting");
             logger.debug(String.format("java.version:[%s] java.vendor:[%s]", System.getProperty("java.version"),
                     System.getProperty("java.vendor")));
+            @SuppressWarnings("resource")
             final ConfigurableApplicationContext applicationContext = new ClassPathXmlApplicationContext(
                     "applicationContext.xml");
             logger.debug("Finished getting ApplicationContext");
@@ -63,8 +64,6 @@ public class RestApplication {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 logger.info("Shutdown hook invoked - Commencing graceful termination of Java process");
                 applicationLifecycleController.shutdownApplication();
-                logger.debug("Closing application context");
-                applicationContext.close();
                 logger.info("Java process terminating");
             }));
             applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress);

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
@@ -55,7 +55,6 @@ public class RestApplication {
             logger.info("Java process starting");
             logger.debug(String.format("java.version:[%s] java.vendor:[%s]", System.getProperty("java.version"),
                     System.getProperty("java.vendor")));
-            @SuppressWarnings("resource")
             final ConfigurableApplicationContext applicationContext = new ClassPathXmlApplicationContext(
                     "applicationContext.xml");
             logger.debug("Finished getting ApplicationContext");
@@ -64,6 +63,8 @@ public class RestApplication {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 logger.info("Shutdown hook invoked - Commencing graceful termination of Java process");
                 applicationLifecycleController.shutdownApplication();
+                logger.debug("Closing application context");
+                applicationContext.close();
                 logger.info("Java process terminating");
             }));
             applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress);


### PR DESCRIPTION
This change adds a new test utility method 'InMemoryMessageVerifier#publishedEvents' for use in service tests. This method returns a list of Events that were published using an InMemoryMessagePublisher. The intention is to enable more flexible testing of published events, other than testing for complete equality with existing method 'InMemoryMessageVerifier#eventPublished'.