### PR TITLE
Add metric-support for tagging organisations

### DIFF
--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
@@ -16,11 +16,6 @@
  */
 package com.clicktravel.cheddar.metrics.intercom;
 
-import io.intercom.api.Company;
-import io.intercom.api.Event;
-import io.intercom.api.Intercom;
-import io.intercom.api.User;
-
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +25,8 @@ import com.clicktravel.cheddar.metrics.MetricCollector;
 import com.clicktravel.cheddar.metrics.MetricOrganisation;
 import com.clicktravel.cheddar.metrics.MetricUser;
 import com.clicktravel.common.functional.Equals;
+
+import io.intercom.api.*;
 
 public class IntercomMetricCollector implements MetricCollector {
     Logger logger = LoggerFactory.getLogger(getClass());
@@ -47,6 +44,11 @@ public class IntercomMetricCollector implements MetricCollector {
     @Override
     public void updateOrganisation(final MetricOrganisation organisation) {
         createOrUpdateIntercomCompany(organisation);
+    }
+
+    @Override
+    public void tagOrganisation(final String tagName, final MetricOrganisation metricOrganisation) {
+        Tag.tag(new Tag().setName(tagName), new Company().setCompanyID(metricOrganisation.id()));
     }
 
     @Override
@@ -69,10 +71,10 @@ public class IntercomMetricCollector implements MetricCollector {
             logger.debug("Error updating a Intercom user: " + intercomUser + " - " + e.getMessage());
         }
     }
-    
+
     @Override
     public void deleteUser(final String userId) {
-    	try {
+        try {
             User.delete(userId);
         } catch (final Exception e) {
             logger.debug("Error deleting a Intercom user: " + userId + " - " + e.getMessage());

--- a/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricCollector.java
+++ b/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricCollector.java
@@ -22,10 +22,12 @@ public interface MetricCollector {
 
     void updateOrganisation(MetricOrganisation metricOrganisation);
 
+    void tagOrganisation(String tagName, MetricOrganisation metricOrganisation);
+
     void createUser(MetricUser user);
 
     void updateUser(MetricUser user);
-    
+
     void deleteUser(String userId);
 
     void sendMetric(Metric metric);


### PR DESCRIPTION
This change adds a new method `MetricCollector#tagOrganisation` for marking an organisation with a tag.