### PR TITLE
[FC-129] Add specific mappers for subclasses of JsonProcessingException to override the standard mappers provided by Jersey

### DIFF
--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
 import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
@@ -1,0 +1,25 @@
+package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
+
+import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    public Response toResponse(final JsonMappingException exception) {
+        if (logger.isDebugEnabled()) {
+            logger.debug(exception.getMessage(), exception);
+        }
+        return Response.status(Response.Status.BAD_REQUEST).entity(buildErrorResponse(exception)).build();
+    }
+
+}

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
@@ -18,14 +18,21 @@ package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
 import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;
 
+import javax.annotation.Priority;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.clicktravel.cheddar.rest.media.MediaTypes;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
+@Provider
+@Produces(MediaTypes.CDM_V1_JSON)
+@Priority(Integer.MAX_VALUE)
 public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonParseExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonParseExceptionMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
 import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonParseExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonParseExceptionMapper.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Click Travel Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
 import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;
@@ -28,21 +12,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.clicktravel.cheddar.rest.media.MediaTypes;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonParseException;
 
 @Provider
 @Produces(MediaTypes.CDM_V1_JSON)
 @Priority(Integer.MAX_VALUE)
-public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
+public class JsonParseExceptionMapper implements ExceptionMapper<JsonParseException> {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
-    public Response toResponse(final JsonProcessingException exception) {
+    public Response toResponse(final JsonParseException exception) {
         if (logger.isDebugEnabled()) {
             logger.debug(exception.getMessage(), exception);
         }
-
         return Response.status(Response.Status.BAD_REQUEST).entity(buildErrorResponse(exception)).build();
     }
 

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonProcessingExceptionMapperUtils.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonProcessingExceptionMapperUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
 import com.clicktravel.schema.canonical.data.model.v1.common.Error;

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonProcessingExceptionMapperUtils.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonProcessingExceptionMapperUtils.java
@@ -1,0 +1,16 @@
+package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
+
+import com.clicktravel.schema.canonical.data.model.v1.common.Error;
+import com.clicktravel.schema.canonical.data.model.v1.common.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class JsonProcessingExceptionMapperUtils {
+
+    public static ErrorResponse buildErrorResponse(final JsonProcessingException exception) {
+        final ErrorResponse errorResponse = new ErrorResponse();
+        final Error error = new Error();
+        error.setDescription("An error occurred during processing the provided JSON content.");
+        errorResponse.getErrors().add(error);
+        return errorResponse;
+    }
+}


### PR DESCRIPTION
The registered Jersey feature `JacksonFeature` for converting JSON to/from Java objects, is also registering two standard mappers for the exceptions thrown during processing: `JsonParseExceptionMapper` and `JsonMappingExceptionMapper`. The problem is that these mappers are disclosing too many details, returning also the class names and part of the stack trace where the error occurred.

During investigating this issue, I found out that Jersey is working as follows when selecting the right mapper for an exception thrown:
- First it selects the mappers that are handling an exception that is the nearest in the class hierarchy from the actual thrown exception. 
- If there are many mappers meeting the previous requirement, then a mapper is selected based on its priority (the priority could be set explicitly, when the mapper is registered, or by annotating the class with @Priority). As the exception mappers are used during response processing, the mapper with the greatest priority is selected.

As the mapper already defined in Cheddar is applied for `JsonProcessingException` and the mappers registered in Jersey are applies for `JsonParseException` and `JsonMappingException` (which are subclasses of `JsonProcessingException`) the first one would never been called, even if it had a bigger priority.
So the solution proposed is to add two new mappers with bigger priority in order to override the existing ones. Also, I kept the existing mapper for the base class for intercepting all the other exceptions. 