### PR TITLE
Fixed dynamodb fetch bug when dealing with compound GSI with hash the same as tables PK hash

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
@@ -254,8 +254,9 @@ public class DynamoDocumentStoreTemplate extends AbstractDynamoDbTemplate {
             final QuerySpec querySpec = QuerySpecBuilder.build(query, itemClass);
             final ItemCollection<QueryOutcome> queryOutcome;
 
-            if (itemConfiguration.primaryKeyDefinition().propertyName().equals(query.getAttributeName())) {
-                // if the query is for the has then call query on table
+            if (itemConfiguration.primaryKeyDefinition().propertyName().equals(query.getAttributeName())
+                    && !(query instanceof CompoundAttributeQuery)) {
+                // if the query is for the hash then call query on table
                 queryOutcome = table.query(querySpec);
             } else {
                 final String indexName = IndexNameBuilder.build(query);

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/StubWithHashAndRangeAndGlobalSecondaryIndexItem.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/StubWithHashAndRangeAndGlobalSecondaryIndexItem.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.infrastructure.persistence.aws.dynamodb;
+
+import com.clicktravel.cheddar.infrastructure.persistence.database.Item;
+
+public class StubWithHashAndRangeAndGlobalSecondaryIndexItem implements Item {
+
+    private String id;
+    private Integer range;
+    private Integer gsiSupportingValue;
+    private Long version;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    public Integer getRange() {
+        return range;
+    }
+
+    public void setRange(final Integer range) {
+        this.range = range;
+    }
+
+    public Integer getGsiSupportingValue() {
+        return gsiSupportingValue;
+    }
+
+    public void setGsiSupportingValue(final Integer gsiSupportingValue) {
+        this.gsiSupportingValue = gsiSupportingValue;
+    }
+
+    @Override
+    public Long getVersion() {
+        return version;
+    }
+
+    @Override
+    public void setVersion(final Long version) {
+        this.version = version;
+
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((gsiSupportingValue == null) ? 0 : gsiSupportingValue.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((range == null) ? 0 : range.hashCode());
+        result = prime * result + ((version == null) ? 0 : version.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final StubWithHashAndRangeAndGlobalSecondaryIndexItem other = (StubWithHashAndRangeAndGlobalSecondaryIndexItem) obj;
+        if (gsiSupportingValue == null) {
+            if (other.gsiSupportingValue != null) {
+                return false;
+            }
+        } else if (!gsiSupportingValue.equals(other.gsiSupportingValue)) {
+            return false;
+        }
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        if (range == null) {
+            if (other.range != null) {
+                return false;
+            }
+        } else if (!range.equals(other.range)) {
+            return false;
+        }
+        if (version == null) {
+            if (other.version != null) {
+                return false;
+            }
+        } else if (!version.equals(other.version)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbDataGenerator.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbDataGenerator.java
@@ -221,8 +221,6 @@ public class DynamoDbDataGenerator {
         return globalSecondaryIndex;
     }
 
-    // Add new method for building another GSI using the code above^
-
     private boolean isTableCreated(final String fullStubItemTableName, final DescribeTableResult describeTableResult) {
         return fullStubItemTableName.equals(describeTableResult.getTable().getTableName())
                 && "ACTIVE".equals(describeTableResult.getTable().getTableStatus());

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDocumentStoreTemplateIntegrationTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDocumentStoreTemplateIntegrationTest.java
@@ -55,6 +55,7 @@ public class DynamoDocumentStoreTemplateIntegrationTest {
         dataGenerator.createStubItemTable();
         dataGenerator.createStubItemWithRangeTable();
         dataGenerator.createStubItemWithGlobalSecondaryIndexTable();
+        dataGenerator.createStubItemWithHashAndRangePrimaryKeyAndCompoundGlobalSecondaryIndexTable();
     }
 
     @Before
@@ -73,11 +74,18 @@ public class DynamoDocumentStoreTemplateIntegrationTest {
                 StubWithGlobalSecondaryIndexItem.class, dataGenerator.getStubItemWithGsiTableName());
         stubItemwithGsiConfiguration
                 .registerIndexes((Arrays.asList(new CompoundIndexDefinition("gsi", "gsiSupportingValue"))));
+        final ItemConfiguration stubItemWithHashAndRangeAndGsiConfiguration = new ItemConfiguration(
+                StubWithHashAndRangeAndGlobalSecondaryIndexItem.class,
+                dataGenerator.getStubItemWithHashAndRangeAndGsiTableName(),
+                new CompoundPrimaryKeyDefinition("id", "range"));
+        stubItemWithHashAndRangeAndGsiConfiguration
+                .registerIndexes((Arrays.asList(new CompoundIndexDefinition("id", "gsiSupportingValue"))));
         itemConfigurations.add(stubItemConfiguration);
         itemConfigurations.add(stubItemWithRangeConfiguration);
         itemConfigurations.add(stubParentItemConfiguration);
         itemConfigurations.add(new VariantItemConfiguration(stubParentItemConfiguration, StubVariantItem.class, "a"));
         itemConfigurations.add(stubItemwithGsiConfiguration);
+        itemConfigurations.add(stubItemWithHashAndRangeAndGsiConfiguration);
         databaseSchemaHolder = new DatabaseSchemaHolder(dataGenerator.getUnitTestSchemaName(), itemConfigurations);
     }
 
@@ -497,6 +505,44 @@ public class DynamoDocumentStoreTemplateIntegrationTest {
         // When
         final Collection<StubWithGlobalSecondaryIndexItem> allItems = dynamoDbTemplate.fetch(query,
                 StubWithGlobalSecondaryIndexItem.class);
+
+        // Then
+        assertEquals(expectedMatchingItems.size(), allItems.size());
+        assertTrue(allItems.containsAll(expectedMatchingItems));
+    }
+
+    @Test
+    public void shouldFetch_withEqualsGsiCompoundAttributeQueryWithHashTheFieldAsTablePrimaryKey() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        final List<StubWithHashAndRangeAndGlobalSecondaryIndexItem> expectedMatchingItems = new ArrayList<StubWithHashAndRangeAndGlobalSecondaryIndexItem>();
+        final String gsiFetchCriteriaValue = Randoms.randomString(10);
+        final Integer gsiSupportingFetchCriteriaValue = Randoms.randomInt(20);
+        final Query query = new CompoundAttributeQuery("id", new Condition(Operators.EQUALS, gsiFetchCriteriaValue),
+                "gsiSupportingValue", new Condition(Operators.EQUALS, gsiSupportingFetchCriteriaValue.toString()));
+
+        for (int i = 0; i < 20; i++) {
+            final StubWithHashAndRangeAndGlobalSecondaryIndexItem item = dataGenerator
+                    .randomStubWithHashAndRangeAndGlobalSecondaryIndexItem();
+
+            if (Randoms.randomBoolean() || item.getId().equals(gsiFetchCriteriaValue)) {
+                item.setId(gsiFetchCriteriaValue);
+
+                if (Randoms.randomBoolean() || item.getGsiSupportingValue().equals(gsiSupportingFetchCriteriaValue)) {
+                    item.setGsiSupportingValue(gsiSupportingFetchCriteriaValue);
+                    expectedMatchingItems.add(item);
+                }
+            }
+
+            dynamoDbTemplate.create(item);
+            createdItemIds.add(item.getId() + item.getRange());
+        }
+
+        // When
+        final Collection<StubWithHashAndRangeAndGlobalSecondaryIndexItem> allItems = dynamoDbTemplate.fetch(query,
+                StubWithHashAndRangeAndGlobalSecondaryIndexItem.class);
 
         // Then
         assertEquals(expectedMatchingItems.size(), allItems.size());

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDocumentStoreTemplateIntegrationTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDocumentStoreTemplateIntegrationTest.java
@@ -512,7 +512,7 @@ public class DynamoDocumentStoreTemplateIntegrationTest {
     }
 
     @Test
-    public void shouldFetch_withEqualsGsiCompoundAttributeQueryWithHashTheFieldAsTablePrimaryKey() {
+    public void shouldFetch_withEqualsCompoundGsiAttributeQueryAndHashKeyTheSameAsTablesHashKey() {
         // Given
         final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
         dynamoDbTemplate.initialize(amazonDynamoDbClient);


### PR DESCRIPTION
It was discovered that when the hash in a compound GSI was the same collumn as that of the tables hash then instead of querying using the range as well it ignored it and on queried on only the hash value. The fix was fairly benign but the testing was a little more complex but has seen to be working.

Signed-off-by: James Butherway <james.butherway@clicktravel.com>