### PR TITLE
Don't write null attributes when saving DynamoDB items

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
@@ -40,6 +40,7 @@ import com.clicktravel.cheddar.infrastructure.persistence.database.exception.Opt
 import com.clicktravel.cheddar.infrastructure.persistence.database.exception.handler.PersistenceExceptionHandler;
 import com.clicktravel.cheddar.infrastructure.persistence.database.query.*;
 import com.clicktravel.cheddar.infrastructure.persistence.exception.PersistenceResourceFailureException;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -60,6 +61,7 @@ public class DynamoDocumentStoreTemplate extends AbstractDynamoDbTemplate {
         mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.setSerializationInclusion(Include.NON_NULL);
         mapper.registerModule(new JodaModule());
     }
 

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplateTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplateTest.java
@@ -150,7 +150,7 @@ public class DynamoDocumentStoreTemplateTest {
         verify(mockTable).putItem(getItemRequestCaptor.capture());
 
         final PutItemSpec spec = getItemRequestCaptor.getValue();
-        assertFalse(spec.getItem().isNull("stringProperty2"));
+        assertFalse(spec.getItem().hasAttribute("stringProperty2"));
     }
 
     @Test


### PR DESCRIPTION
An issue was found where data was being written to a compound GSI without the range part of the key.  This is something which DynamoDB allows but the Cheddar process of converting the item POJOs into JSON was including the null attributes explicitly mapped as null which is not allowed within Dynamo.  This fixes that issue by only writing properties to DynamoDB if they are not null.