### PR TITLE
Upgrade Powermock 1.6.3 -> 1.6.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@
 def checkstyleConfigDir = new File(rootDir, 'config/checkstyle')
 
 // Select all non-empty subprojects
-def subproj = subprojects.findAll{ new File(it.projectDir, "src").exists() }
+def subproj = subprojects.findAll { new File(it.projectDir, "src").exists() }
 
 // Add clean task to all projects
 allprojects { apply plugin: 'base' }
@@ -50,16 +50,8 @@ configure(subproj) {
         configFile = new File(checkstyleConfigDir, "checkstyle.xml")
         configProperties.checkstyleConfigDir = checkstyleConfigDir
     }
-    
-    configurations.all {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            // Use org.mockito:mockito-core:xxx rather than org.mockito:mockito-all:xxx
-            // This fixes Powermock's transitive dependencies conflicting with org.hamcrest:hamcrest-core
-            if (details.requested.group == 'org.mockito' && details.requested.name == 'mockito-all') {
-                details.useTarget "org.mockito:mockito-core:${details.requested.version}"
-            }
-        }
 
+    configurations.all {
         // Remove Jakarta Commons Logging
         exclude(group: 'commons-logging', module: 'commons-logging')
     }
@@ -78,7 +70,9 @@ task checkstyleAggregate {
     doLast {
         def reportFiles = fileTree(rootDir).include('**/checkstyle/main.xml', '**/checkstyle/test.xml')
         def reportDir = new File("${project.buildDir}/reports/checkstyle")
-        if( !reportDir.exists() ) { reportDir.mkdirs() }
+        if (!reportDir.exists()) {
+            reportDir.mkdirs()
+        }
         def file = new File("${reportDir}/aggregate.xml")
         def fileElemWriter = new PrintWriter(file)
         fileElemWriter.print('<checkstyle version="5.6">')
@@ -104,11 +98,13 @@ def integrationTestTask = tasks.getByPath(':cheddar:cheddar-integration-aws:inte
 task checkAllWithIntegrationIfNeeded {
     description 'Check all subprojects and follow with integration tests if needed'
     dependsOn { checkAll }
-    if (runIntegrationTests) { dependsOn { integrationTestTask } }
+    if (runIntegrationTests) {
+        dependsOn { integrationTestTask }
+    }
 }
 integrationTestTask.mustRunAfter checkAll
 
-task uploadAll (dependsOn: subproj.uploadArchives) {
+task uploadAll(dependsOn: subproj.uploadArchives) {
     description 'Upload source and binaries for all subprojects'
     doLast {
         println "Uploaded Cheddar version ${version}"
@@ -123,5 +119,5 @@ uploadAll.mustRunAfter checkAllWithIntegrationIfNeeded
 
 task wrapper(type: Wrapper) {
     description "Produce Gradle Wrapper scripts for running Gradle on machines that don't have Gradle installed"
-    gradleVersion = '2.9'
+    gradleVersion = '3.3'
 }

--- a/commons/commons-lang/build.gradle
+++ b/commons/commons-lang/build.gradle
@@ -2,8 +2,8 @@ dependencies {
     compile "joda-time:joda-time:${jodaTimeVersion}"
     compile 'javax.mail:mail:1.4.7'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.3'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.3'
+    testCompile "junit:junit:${junitVersion}"
+    testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"
+    testCompile "org.powermock:powermock-api-mockito:${powermockVersion}"
+    testCompile "org.powermock:powermock-module-junit4:${powermockVersion}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
-springVersion=4.1.1.RELEASE
 awsJavaSdkVersion=1.11.6
+hamcrestVersion=1.3
 jacksonVersion=2.7.4
 jerseyVersion=2.22.2
 jodaTimeVersion=2.8.2
+junitVersion=4.12
+powermockVersion=1.6.5
 slf4jVersion=1.7.21
+springVersion=4.1.1.RELEASE

--- a/test.gradle
+++ b/test.gradle
@@ -1,7 +1,7 @@
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.3'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.3'
+    testCompile "junit:junit:${junitVersion}"
+    testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"
+    testCompile "org.powermock:powermock-api-mockito:${powermockVersion}"
+    testCompile "org.powermock:powermock-module-junit4:${powermockVersion}"
     testCompile project(':commons:commons-lang')
 }


### PR DESCRIPTION
Powermock 1.6.3 has bad dependency metadata which required a workaround in Cheddar’s build script to change its transitive dependencies. Powermock 1.6.5 has corrected metadata, obsoleting the workaround.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>