### PR TITLE
Fixed intercom metric collector to work with new company assigning

### DIFF
--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
@@ -17,6 +17,7 @@
 package com.clicktravel.cheddar.metrics.intercom;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -81,7 +82,7 @@ public class IntercomMetricCollector implements MetricCollector {
     @Override
     public void addCustomAttributesToUser(final String userId, final Map<String, Object> customAttributes) {
         try {
-            final User intercomUser = User.find(userId);
+            final User intercomUser = findIntercomUserByUserId(userId);
 
             customAttributes.entrySet().stream().forEach(entry -> {
                 final String key = entry.getKey();
@@ -111,7 +112,7 @@ public class IntercomMetricCollector implements MetricCollector {
     @Override
     public void addOrganisationToUser(final String userId, final String organisationId) {
         try {
-            final User intercomUser = User.find(userId);
+            final User intercomUser = findIntercomUserByUserId(userId);
             final Company company = new Company();
             company.setCompanyID(organisationId);
 
@@ -127,7 +128,7 @@ public class IntercomMetricCollector implements MetricCollector {
     @Override
     public void removeOrganisationFromUser(final String userId, final String organisationId) {
         try {
-            final User intercomUser = User.find(userId);
+            final User intercomUser = findIntercomUserByUserId(userId);
             final Company company = new Company();
             company.setCompanyID(organisationId);
 
@@ -195,7 +196,7 @@ public class IntercomMetricCollector implements MetricCollector {
 
         User intercomUser = null;
         try {
-            intercomUser = User.find(userId);
+            intercomUser = findIntercomUserByUserId(userId);
         } catch (final Exception e) {
             logger.warn("Failed to get user with Id: {} from Intercom - {}", userId, e.getMessage());
             throw new MetricUserNotFoundException(userId);
@@ -217,6 +218,7 @@ public class IntercomMetricCollector implements MetricCollector {
 
         final User intercomUser = new User();
         intercomUser.setId(user.id());
+        intercomUser.setUserId(user.id());
         intercomUser.setName(user.name());
 
         if (!Equals.isNullOrBlank(user.emailAddress())) {
@@ -265,4 +267,11 @@ public class IntercomMetricCollector implements MetricCollector {
             logger.warn("Error creating/updating a Intercom company: {} - {}", company, e.getMessage());
         }
     }
+
+    private User findIntercomUserByUserId(final String travelCloudUserId) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", travelCloudUserId);
+        return User.find(params);
+    }
+
 }

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
@@ -70,8 +70,10 @@ public class IntercomMetricCollectorTest {
     public void shouldAddBooleanCustomAttributeToUser_withBooleanAttribute() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Map<String, Object> customAttributes = new HashMap<>();
         final BooleanAttribute booleanAttribute = mock(BooleanAttribute.class);
         final String name = randomString(5);
@@ -94,8 +96,10 @@ public class IntercomMetricCollectorTest {
     public void shouldAddStringCustomAttributeToUser_withStringAttribute() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Map<String, Object> customAttributes = new HashMap<>();
         final StringAttribute stringAttribute = mock(StringAttribute.class);
         final String name = randomString(5);
@@ -118,8 +122,10 @@ public class IntercomMetricCollectorTest {
     public void shouldAddIntegerCustomAttributeToUser_withIntegerAttribute() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Map<String, Object> customAttributes = new HashMap<>();
         final IntegerAttribute integerAttribute = mock(IntegerAttribute.class);
         final String name = randomString(5);
@@ -142,8 +148,10 @@ public class IntercomMetricCollectorTest {
     public void shouldAddDoubleCustomAttributeToUser_withDoubleAttribute() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Map<String, Object> customAttributes = new HashMap<>();
         final DoubleAttribute doubleAttribute = mock(DoubleAttribute.class);
         final String name = randomString(5);
@@ -166,8 +174,10 @@ public class IntercomMetricCollectorTest {
     public void shouldAddLongCustomAttributeToUser_withLongAttribute() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Map<String, Object> customAttributes = new HashMap<>();
         final LongAttribute longAttribute = mock(LongAttribute.class);
         final String name = randomString(5);
@@ -190,8 +200,10 @@ public class IntercomMetricCollectorTest {
     public void shouldAddFloatCustomAttributeToUser_withFloatAttribute() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Map<String, Object> customAttributes = new HashMap<>();
         final FloatAttribute floatAttribute = mock(FloatAttribute.class);
         final String name = randomString(5);
@@ -214,8 +226,10 @@ public class IntercomMetricCollectorTest {
     public void shouldAddValidCustomAttributesToUser_withValidAndInvalidAttribute() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
 
         final Map<String, Object> customAttributes = new HashMap<>();
         customAttributes.put(randomString(5), new Object());
@@ -249,7 +263,9 @@ public class IntercomMetricCollectorTest {
     public void shouldNotAddCustomAttributesToUser_withIntercomFindUserException() {
         // Given
         final String userId = randomId();
-        when(User.find(userId)).thenThrow(Exception.class);
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
+        when(User.find(params)).thenThrow(Exception.class);
         final Map<String, Object> customAttributes = mock(Map.class);
 
         // When
@@ -264,9 +280,11 @@ public class IntercomMetricCollectorTest {
     public void shouldAddOrganisationToUser_withUserIdAndOrganisationId() throws Exception {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final String organisationId = randomId();
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Company mockCompany = mock(Company.class);
         whenNew(Company.class).withNoArguments().thenReturn(mockCompany);
 
@@ -284,8 +302,10 @@ public class IntercomMetricCollectorTest {
     public void shouldNotAddOrganisationToUser_withUserIdAndOrganisationIdAndIntercomFindUserException() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final String organisationId = randomId();
-        when(User.find(userId)).thenThrow(Exception.class);
+        when(User.find(params)).thenThrow(Exception.class);
 
         // When
         intercomMetricCollector.addOrganisationToUser(userId, organisationId);
@@ -298,9 +318,11 @@ public class IntercomMetricCollectorTest {
     public void shouldRemoveOrganisationFromUser_withUserIdAndOrganisationId() throws Exception {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final String organisationId = randomId();
         final User mockUser = mock(User.class);
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
         final Company mockCompany = mock(Company.class);
         whenNew(Company.class).withNoArguments().thenReturn(mockCompany);
         when(Company.find(organisationId)).thenReturn(mockCompany);
@@ -319,8 +341,10 @@ public class IntercomMetricCollectorTest {
     public void shouldNotRemoveOrganisationFromUser_withUserIdAndOrganisationIdAndIntercomFindUserException() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final String organisationId = randomId();
-        when(User.find(userId)).thenThrow(Exception.class);
+        when(User.find(params)).thenThrow(Exception.class);
 
         // When
         intercomMetricCollector.removeOrganisationFromUser(userId, organisationId);
@@ -334,8 +358,10 @@ public class IntercomMetricCollectorTest {
     public void shouldReturnUser_withUserId() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User mockUser = randomUser();
-        when(User.find(userId)).thenReturn(mockUser);
+        when(User.find(params)).thenReturn(mockUser);
 
         // When
         final MetricUser result = intercomMetricCollector.getUser(userId);
@@ -376,8 +402,10 @@ public class IntercomMetricCollectorTest {
     public void shouldNotReturnUser_withExceptionThrownByIntercom() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
 
-        when(User.find(userId)).thenThrow(Exception.class);
+        when(User.find(params)).thenThrow(Exception.class);
 
         // When
         MetricUserNotFoundException thrownException = null;
@@ -395,9 +423,11 @@ public class IntercomMetricCollectorTest {
     public void shouldNotReturnUser_withNullUserReturnedByIntercom() {
         // Given
         final String userId = randomId();
+        final Map<String, String> params = new HashMap<>();
+        params.put("user_id", userId);
         final User user = null;
 
-        when(User.find(userId)).thenReturn(user);
+        when(User.find(params)).thenReturn(user);
 
         // When
         MetricUserNotFoundException thrownException = null;

--- a/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
+++ b/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
@@ -16,10 +16,7 @@
  */
 package com.clicktravel.cheddar.metrics;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MetricUser {
 
@@ -28,6 +25,15 @@ public class MetricUser {
     private final String name;
     private final String emailAddress;
     private final Map<String, Object> customAttributes;
+
+    public MetricUser(final String id, final String organisationId, final String name, final String emailAddress) {
+        super();
+        this.id = id;
+        organisationIds = organisationId != null ? Arrays.asList(organisationId) : new ArrayList<>();
+        this.name = name;
+        this.emailAddress = emailAddress;
+        customAttributes = new HashMap<>();
+    }
 
     public MetricUser(final String id, final List<String> organisationIds, final String name, final String emailAddress,
             final Map<String, Object> customAttributes) {
@@ -39,21 +45,16 @@ public class MetricUser {
         this.customAttributes = customAttributes;
     }
 
-    public MetricUser(final String id, final String name, final String emailAddress) {
-        super();
-        this.id = id;
-        organisationIds = new ArrayList<>();
-        this.name = name;
-        this.emailAddress = emailAddress;
-        customAttributes = new HashMap<>();
-    }
-
     public String id() {
         return id;
     }
 
     public List<String> organisationIds() {
         return organisationIds;
+    }
+
+    public String organisationId() {
+        return organisationIds != null ? organisationIds.get(0) : null;
     }
 
     public String name() {

--- a/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
+++ b/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
@@ -16,6 +16,8 @@
  */
 package com.clicktravel.cheddar.metrics;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +37,15 @@ public class MetricUser {
         this.name = name;
         this.emailAddress = emailAddress;
         this.customAttributes = customAttributes;
+    }
+
+    public MetricUser(final String id, final String name, final String emailAddress) {
+        super();
+        this.id = id;
+        organisationIds = new ArrayList<>();
+        this.name = name;
+        this.emailAddress = emailAddress;
+        customAttributes = new HashMap<>();
     }
 
     public String id() {


### PR DESCRIPTION
- Added setting and fetching by userId allowing users to actaully be gotten by Users.find()
- Added second simpler constructor for a metric user that will be used when a user is created without company id’s or custom attributes
- Updated unit tests to work with new way of finding

Signed-off-by: James Butherway <james.butherway@clicktravel.com>