### PR TITLE
[IAM-1667] IntercomMetricsAdaptor CustomAttributes API Issue

### DIFF
--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomCustomAttributeToMetricCustomAttributeMapper.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomCustomAttributeToMetricCustomAttributeMapper.java
@@ -42,9 +42,9 @@ public class IntercomCustomAttributeToMetricCustomAttributeMapper
             if (value == null || value.getValue() == null) {
                 customAttributes.put(key, null);
             } else if (value.getValueClass().equals(Boolean.class)) {
-                customAttributes.put(key, (new Boolean(value.booleanValue())));
+                customAttributes.put(key, (value.booleanValue()));
             } else if (value.getValueClass().equals(Integer.class)) {
-                customAttributes.put(key, (new Integer(value.integerValue())));
+                customAttributes.put(key, (value.integerValue()));
             } else if (value.getValueClass().equals(Double.class)) {
                 customAttributes.put(key, (value.doubleValue()));
             } else if (value.getValueClass().equals(Long.class)) {

--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomCustomAttributeToMetricCustomAttributeMapper.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomCustomAttributeToMetricCustomAttributeMapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.metrics.intercom;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.intercom.api.CustomAttribute;
+
+@SuppressWarnings("rawtypes")
+public class IntercomCustomAttributeToMetricCustomAttributeMapper
+        implements Function<Map<String, CustomAttribute>, Map<String, Object>> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Map<String, Object> apply(final Map<String, CustomAttribute> intercomCustomAttributes) {
+        if (intercomCustomAttributes == null) {
+            return null;
+        }
+        final Map<String, Object> customAttributes = new HashMap<>();
+        intercomCustomAttributes.entrySet().stream().forEach(entry -> {
+            final String key = entry.getKey();
+            final CustomAttribute value = entry.getValue();
+            if (value == null || value.getValue() == null) {
+                customAttributes.put(key, null);
+            } else if (value.getValueClass().equals(Boolean.class)) {
+                customAttributes.put(key, (new Boolean(value.booleanValue())));
+            } else if (value.getValueClass().equals(Integer.class)) {
+                customAttributes.put(key, (new Integer(value.integerValue())));
+            } else if (value.getValueClass().equals(Double.class)) {
+                customAttributes.put(key, (value.doubleValue()));
+            } else if (value.getValueClass().equals(Long.class)) {
+                customAttributes.put(key, (value.longValue()));
+            } else if (value.getValueClass().equals(Float.class)) {
+                customAttributes.put(key, (value.floatValue()));
+            } else if (value.getValueClass().equals(String.class)) {
+                customAttributes.put(key, (value.textValue()));
+            } else {
+                logger.warn("Unsupported custom attribute class : {}", value.getValueClass().getSimpleName());
+            }
+        });
+        return customAttributes;
+    }
+}

--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
@@ -224,8 +224,6 @@ public class IntercomMetricCollector implements MetricCollector {
     @SuppressWarnings("rawtypes")
     private Map<String, Object> getCustomAttributes(final User user) {
         final Map<String, CustomAttribute> customAttributes = user.getCustomAttributes();
-        // return customAttributes.entrySet().stream().collect(
-        // Collectors.toMap(entry -> entry.getKey(), entry -> (CustomAttribute) (entry.getValue().getValue())));
         return intercomToMetricCustomAttributeMapper.apply(customAttributes);
     }
 

--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
@@ -34,7 +34,7 @@ import io.intercom.api.*;
 public class IntercomMetricCollector implements MetricCollector {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private MetricCustomAttributeToIntercomCustomAttributeMapper metricToIntercomCustomAttributeMapper;
-    private final IntercomCustomAttributeToMetricCustomAttributeMapper intercomToMetricCustomAttributeMapper;
+    private IntercomCustomAttributeToMetricCustomAttributeMapper intercomToMetricCustomAttributeMapper;
 
     public IntercomMetricCollector(final String personalAccessToken) {
         Intercom.setToken(personalAccessToken);
@@ -42,8 +42,14 @@ public class IntercomMetricCollector implements MetricCollector {
         intercomToMetricCustomAttributeMapper = new IntercomCustomAttributeToMetricCustomAttributeMapper();
     }
 
-    void setCustomAttributeMapper(final MetricCustomAttributeToIntercomCustomAttributeMapper customAttributeMapper) {
+    void setMetricToIntercomCustomAttributeMapper(
+            final MetricCustomAttributeToIntercomCustomAttributeMapper customAttributeMapper) {
         metricToIntercomCustomAttributeMapper = customAttributeMapper;
+    }
+
+    void setIntercomToMetricCustomAttributeMapper(
+            final IntercomCustomAttributeToMetricCustomAttributeMapper customAttributeMapper) {
+        intercomToMetricCustomAttributeMapper = customAttributeMapper;
     }
 
     @Override

--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/MetricCustomAttributeToIntercomCustomAttributeMapper.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/MetricCustomAttributeToIntercomCustomAttributeMapper.java
@@ -39,7 +39,9 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapper
         metricCustomAttributes.entrySet().stream().forEach(entry -> {
             final String key = entry.getKey();
             final Object value = entry.getValue();
-            if (value.getClass().equals(Boolean.class)) {
+            if (value == null) {
+                customAttributes.put(key, null);
+            } else if (value.getClass().equals(Boolean.class)) {
                 customAttributes.put(key, CustomAttribute.newBooleanAttribute(key, (Boolean) value));
             } else if (value.getClass().equals(Integer.class)) {
                 customAttributes.put(key, CustomAttribute.newIntegerAttribute(key, (Integer) value));

--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/MetricCustomAttributeToIntercomCustomAttributeMapper.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/MetricCustomAttributeToIntercomCustomAttributeMapper.java
@@ -40,7 +40,7 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapper
             final String key = entry.getKey();
             final Object value = entry.getValue();
             if (value == null) {
-                customAttributes.put(key, null);
+                customAttributes.put(key, CustomAttribute.newStringAttribute(key, null));
             } else if (value.getClass().equals(Boolean.class)) {
                 customAttributes.put(key, CustomAttribute.newBooleanAttribute(key, (Boolean) value));
             } else if (value.getClass().equals(Integer.class)) {

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomCustomAttributeToMetricCustomAttributeMapperTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomCustomAttributeToMetricCustomAttributeMapperTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.metrics.intercom;
+
+import static com.clicktravel.common.random.Randoms.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.intercom.api.CustomAttribute;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ CustomAttribute.class })
+@SuppressWarnings("rawtypes")
+public class IntercomCustomAttributeToMetricCustomAttributeMapperTest {
+
+    private IntercomCustomAttributeToMetricCustomAttributeMapper mapper;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(CustomAttribute.class);
+        mapper = new IntercomCustomAttributeToMetricCustomAttributeMapper();
+    }
+
+    @Test
+    public void shouldMapToBooleanAttribute_withBooleanCustomAttribute() {
+        // Given
+        final String name = randomString(10);
+        final boolean value = new Boolean(randomBoolean());
+        final CustomAttribute mockBooleanAttribute = mock(CustomAttribute.class);
+        when(mockBooleanAttribute.getValueClass()).thenReturn(Boolean.class);
+        when(mockBooleanAttribute.getName()).thenReturn(name);
+        when(mockBooleanAttribute.getValue()).thenReturn(value);
+        when(mockBooleanAttribute.booleanValue()).thenReturn(value);
+
+        final Map<String, CustomAttribute> intercomCustomAttributes = new HashMap<>();
+        intercomCustomAttributes.put(name, mockBooleanAttribute);
+
+        // When
+        final Map<String, Object> result = mapper.apply(intercomCustomAttributes);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result.get(name), value);
+    }
+
+    @Test
+    public void shouldMapToIntegerAttribute_withIntegerCustomAttribute() {
+        // Given
+        final String name = randomString(10);
+        final int value = randomIntInRange(-10, 10);
+        final CustomAttribute mockIntegerAttribute = mock(CustomAttribute.class);
+        when(mockIntegerAttribute.getValueClass()).thenReturn(Integer.class);
+        when(mockIntegerAttribute.getName()).thenReturn(name);
+        when(mockIntegerAttribute.getValue()).thenReturn(value);
+        when(mockIntegerAttribute.integerValue()).thenReturn(value);
+
+        final Map<String, CustomAttribute> intercomCustomAttributes = new HashMap<>();
+        intercomCustomAttributes.put(name, mockIntegerAttribute);
+
+        // When
+        final Map<String, Object> result = mapper.apply(intercomCustomAttributes);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result.get(name), value);
+    }
+
+    @Test
+    public void shouldMapToLongAttribute_withLongCustomAttribute() {
+        // Given
+        final String name = randomString(10);
+        final long value = new Long(randomIntInRange(-10, 10));
+        final CustomAttribute mockLongAttribute = mock(CustomAttribute.class);
+        when(mockLongAttribute.getValueClass()).thenReturn(Long.class);
+        when(mockLongAttribute.getName()).thenReturn(name);
+        when(mockLongAttribute.getValue()).thenReturn(value);
+        when(mockLongAttribute.longValue()).thenReturn(value);
+
+        final Map<String, CustomAttribute> intercomCustomAttributes = new HashMap<>();
+        intercomCustomAttributes.put(name, mockLongAttribute);
+
+        // When
+        final Map<String, Object> result = mapper.apply(intercomCustomAttributes);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result.get(name), value);
+    }
+
+    @Test
+    public void shouldMapToFloatAttribute_withFloatCustomAttribute() {
+        // Given
+        final String name = randomString(10);
+        final float value = randomFloat();
+        final CustomAttribute mockFloatAttribute = mock(CustomAttribute.class);
+        when(mockFloatAttribute.getValueClass()).thenReturn(Float.class);
+        when(mockFloatAttribute.getName()).thenReturn(name);
+        when(mockFloatAttribute.getValue()).thenReturn(value);
+        when(mockFloatAttribute.floatValue()).thenReturn(value);
+
+        final Map<String, CustomAttribute> intercomCustomAttributes = new HashMap<>();
+        intercomCustomAttributes.put(name, mockFloatAttribute);
+
+        // When
+        final Map<String, Object> result = mapper.apply(intercomCustomAttributes);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result.get(name), value);
+    }
+
+    @Test
+    public void shouldMapToDoubleAttribute_withDoubleCustomAttribute() {
+        // Given
+        final String name = randomString(10);
+        final double value = randomDouble();
+        final CustomAttribute mockFloatAttribute = mock(CustomAttribute.class);
+        when(mockFloatAttribute.getValueClass()).thenReturn(Double.class);
+        when(mockFloatAttribute.getName()).thenReturn(name);
+        when(mockFloatAttribute.getValue()).thenReturn(value);
+        when(mockFloatAttribute.doubleValue()).thenReturn(value);
+
+        final Map<String, CustomAttribute> intercomCustomAttributes = new HashMap<>();
+        intercomCustomAttributes.put(name, mockFloatAttribute);
+
+        // When
+        final Map<String, Object> result = mapper.apply(intercomCustomAttributes);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result.get(name), value);
+    }
+
+    @Test
+    public void shouldMapToStringAttribute_withStringCustomAttribute() {
+        // Given
+        final String name = randomString(10);
+        final String value = randomString();
+        final CustomAttribute mockStringAttribute = mock(CustomAttribute.class);
+        when(mockStringAttribute.getValueClass()).thenReturn(String.class);
+        when(mockStringAttribute.getName()).thenReturn(name);
+        when(mockStringAttribute.getValue()).thenReturn(value);
+        when(mockStringAttribute.textValue()).thenReturn(value);
+
+        final Map<String, CustomAttribute> intercomCustomAttributes = new HashMap<>();
+        intercomCustomAttributes.put(name, mockStringAttribute);
+        // When
+        final Map<String, Object> result = mapper.apply(intercomCustomAttributes);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result.get(name), value);
+    }
+
+    @Test
+    public void shouldMapToNullAttribute_withNullCustomAttribute() {
+        // Given
+        final Map<String, CustomAttribute> intercomCustomAttributes = new HashMap<>();
+        final String name = randomString();
+        final CustomAttribute intercomCustomAttribute = CustomAttribute.newStringAttribute(name, null);
+        intercomCustomAttributes.put(name, intercomCustomAttribute);
+
+        // When
+        final Map<String, Object> result = mapper.apply(intercomCustomAttributes);
+
+        // Then
+        assertNotNull(result);
+        assertNull(result.get(name));
+    }
+
+}

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
@@ -377,10 +377,4 @@ public class IntercomMetricCollectorTest {
         // Then
         assertNotNull(thrownException);
     }
-
-    /*
-     * @Test void shouldReturnCustomAttributes_withUser() { // Given final User intercomUser = randomIntercomUser();
-     *
-     * // When final Map<String, Object> customAttributes = intercomMetricCollector.getCustomAttributes(intercomUser); }
-     */
 }

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
@@ -314,7 +314,7 @@ public class IntercomMetricCollectorTest {
         assertThat(result.customAttributes().size(), is(mockUser.getCustomAttributes().size()));
         mockUser.getCustomAttributes().entrySet().forEach(entry -> {
             assertTrue(result.customAttributes().containsKey(entry.getKey()));
-            assertThat(result.customAttributes().get(entry.getKey()), is(entry.getValue()));
+            assertThat(result.customAttributes().get(entry.getKey()), is(entry.getValue().getValue()));
         });
     }
 
@@ -378,4 +378,9 @@ public class IntercomMetricCollectorTest {
         assertNotNull(thrownException);
     }
 
+    /*
+     * @Test void shouldReturnCustomAttributes_withUser() { // Given final User intercomUser = randomIntercomUser();
+     *
+     * // When final Map<String, Object> customAttributes = intercomMetricCollector.getCustomAttributes(intercomUser); }
+     */
 }

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
@@ -60,7 +60,8 @@ import io.intercom.api.User;
 @PrepareForTest({ User.class, Company.class, IntercomMetricCollector.class, Tag.class })
 public class IntercomMetricCollectorTest {
 
-    private MetricCustomAttributeToIntercomCustomAttributeMapper customAttributeMapper;
+    private MetricCustomAttributeToIntercomCustomAttributeMapper metricToIntercomMapper;
+    private IntercomCustomAttributeToMetricCustomAttributeMapper intercomToMetricMapper;
     private IntercomMetricCollector intercomMetricCollector;
 
     @Before
@@ -69,9 +70,11 @@ public class IntercomMetricCollectorTest {
         PowerMockito.mockStatic(Company.class);
         PowerMockito.mockStatic(Tag.class);
         final String personalAccessToken = randomString();
-        customAttributeMapper = mock(MetricCustomAttributeToIntercomCustomAttributeMapper.class);
+        metricToIntercomMapper = mock(MetricCustomAttributeToIntercomCustomAttributeMapper.class);
+        intercomToMetricMapper = mock(IntercomCustomAttributeToMetricCustomAttributeMapper.class);
         intercomMetricCollector = new IntercomMetricCollector(personalAccessToken);
-        intercomMetricCollector.setCustomAttributeMapper(customAttributeMapper);
+        intercomMetricCollector.setMetricToIntercomCustomAttributeMapper(metricToIntercomMapper);
+        intercomMetricCollector.setIntercomToMetricCustomAttributeMapper(intercomToMetricMapper);
     }
 
     @Test
@@ -131,7 +134,7 @@ public class IntercomMetricCollectorTest {
         // Given
         final MetricUser metricUser = randomMetricUser();
         final Map<String, CustomAttribute> customAttributes = mock(Map.class);
-        when(customAttributeMapper.apply(metricUser.customAttributes())).thenReturn(customAttributes);
+        when(metricToIntercomMapper.apply(metricUser.customAttributes())).thenReturn(customAttributes);
         DateTimeUtils.setCurrentMillisFixed(DateTime.now().getMillis());
         // When
         intercomMetricCollector.createUser(metricUser);
@@ -156,7 +159,7 @@ public class IntercomMetricCollectorTest {
         // Given
         final MetricUser metricUser = randomMetricUser();
         final Map<String, CustomAttribute> customAttributes = mock(Map.class);
-        when(customAttributeMapper.apply(metricUser.customAttributes())).thenReturn(customAttributes);
+        when(metricToIntercomMapper.apply(metricUser.customAttributes())).thenReturn(customAttributes);
         // When
         intercomMetricCollector.updateUser(metricUser);
 
@@ -185,7 +188,7 @@ public class IntercomMetricCollectorTest {
         params.put("user_id", userId);
         when(User.find(params)).thenReturn(mockUser);
         final Map<String, CustomAttribute> mockCustomAttributes = mock(Map.class);
-        when(customAttributeMapper.apply(customAttributes)).thenReturn(mockCustomAttributes);
+        when(metricToIntercomMapper.apply(customAttributes)).thenReturn(mockCustomAttributes);
 
         // When
         intercomMetricCollector.addCustomAttributesToUser(userId, customAttributes);
@@ -299,6 +302,8 @@ public class IntercomMetricCollectorTest {
         params.put("user_id", userId);
         final User mockUser = randomIntercomUser();
         when(User.find(params)).thenReturn(mockUser);
+        final Map<String, Object> mockCustomAttributes = mock(Map.class);
+        when(intercomToMetricMapper.apply(mockUser.getCustomAttributes())).thenReturn(mockCustomAttributes);
 
         // When
         final MetricUser result = intercomMetricCollector.getUser(userId);
@@ -311,11 +316,7 @@ public class IntercomMetricCollectorTest {
         });
         assertThat(result.name(), is(mockUser.getName()));
         assertThat(result.emailAddress(), is(mockUser.getEmail()));
-        assertThat(result.customAttributes().size(), is(mockUser.getCustomAttributes().size()));
-        mockUser.getCustomAttributes().entrySet().forEach(entry -> {
-            assertTrue(result.customAttributes().containsKey(entry.getKey()));
-            assertThat(result.customAttributes().get(entry.getKey()), is(entry.getValue().getValue()));
-        });
+        assertThat(result.customAttributes(), is(mockCustomAttributes));
     }
 
     @Test

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/MetricCustomAttributeToIntercomCustomAttributeMapperTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/MetricCustomAttributeToIntercomCustomAttributeMapperTest.java
@@ -45,12 +45,12 @@ import io.intercom.api.CustomAttribute.*;
 @SuppressWarnings("rawtypes")
 public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
 
-    private MetricCustomAttributeToIntercomCustomAttributeMapper mapper;
+    private MetricCustomAttributeToIntercomCustomAttributeMapper metricToIntercomMapper;
 
     @Before
     public void setUp() {
         PowerMockito.mockStatic(CustomAttribute.class);
-        mapper = new MetricCustomAttributeToIntercomCustomAttributeMapper();
+        metricToIntercomMapper = new MetricCustomAttributeToIntercomCustomAttributeMapper();
     }
 
     @Test
@@ -64,7 +64,7 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
         when(CustomAttribute.newBooleanAttribute(name, value)).thenReturn(mockBooleanAttribute);
 
         // When
-        final Map<String, CustomAttribute> result = mapper.apply(metricCustomAttribute);
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
 
         // Then
         assertNotNull(result);
@@ -83,7 +83,7 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
         when(CustomAttribute.newStringAttribute(name, value)).thenReturn(mockStringAttribute);
 
         // When
-        final Map<String, CustomAttribute> result = mapper.apply(metricCustomAttribute);
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
 
         // Then
         assertNotNull(result);
@@ -101,7 +101,7 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
         when(CustomAttribute.newIntegerAttribute(name, value)).thenReturn(mockIntegerAttribute);
 
         // When
-        final Map<String, CustomAttribute> result = mapper.apply(metricCustomAttribute);
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
 
         // Then
         assertNotNull(result);
@@ -119,7 +119,7 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
         when(CustomAttribute.newDoubleAttribute(name, value)).thenReturn(mockDoubleAttribute);
 
         // When
-        final Map<String, CustomAttribute> result = mapper.apply(metricCustomAttribute);
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
 
         // Then
         assertNotNull(result);
@@ -137,7 +137,7 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
         when(CustomAttribute.newLongAttribute(name, value)).thenReturn(mockLongAttribute);
 
         // When
-        final Map<String, CustomAttribute> result = mapper.apply(metricCustomAttribute);
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
 
         // Then
         assertNotNull(result);
@@ -154,11 +154,28 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
         when(CustomAttribute.newFloatAttribute(name, value)).thenReturn(mockFloatAttribute);
 
         // When
-        final Map<String, CustomAttribute> result = mapper.apply(metricCustomAttribute);
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
 
         // Then
         assertNotNull(result);
         assertThat(result.get(name), is(mockFloatAttribute));
+    }
+
+    @Test
+    public void shouldMapToNullCustomAttribute_withNullAttribute() {
+        // Given
+        final Map<String, Object> metricCustomAttribute = new HashMap<>();
+        final String name = randomString();
+        metricCustomAttribute.put(name, null);
+        final StringAttribute mockNullAttribute = mock(StringAttribute.class);
+        when(CustomAttribute.newStringAttribute(name, null)).thenReturn(mockNullAttribute);
+
+        // When
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
+
+        // Then
+        assertNotNull(result);
+        assertThat(result.get(name), is(mockNullAttribute));
     }
 
     @Test
@@ -187,7 +204,7 @@ public class MetricCustomAttributeToIntercomCustomAttributeMapperTest {
         expectedAttributes.put(integerKey, integerAttribute);
 
         // When
-        final Map<String, CustomAttribute> result = mapper.apply(metricCustomAttribute);
+        final Map<String, CustomAttribute> result = metricToIntercomMapper.apply(metricCustomAttribute);
 
         // Then
         assertNotNull(result);


### PR DESCRIPTION
`MetricUser` now contains Custom Attributes in a consistent non-intercom-dependent format when passed to / from `IntercomMetricCollector`, or updated directly with `addCustomAttributesToUser()`