### PR TITLE
Ensure that when a non-compound attribute query is passed for an index which is also the hash part of a compound index, we use the non-compound index to query against

### DIFF
--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/configuration/ItemConfiguration.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/configuration/ItemConfiguration.java
@@ -204,7 +204,7 @@ public class ItemConfiguration {
             stringBuffer.append(compoundName(attributeQuery.getAttributeName(),
                     compoundAttributeQuery.getSupportingAttributeName()));
         } else {
-            if (compoundIndexHashKeyToIndexNameMap.keySet().contains(attributeQuery.getAttributeName())) {
+            if (isAttributeHashOfACompoundIndexButDoesNotHaveANonCompoundIndexOnIt(attributeQuery.getAttributeName())) {
                 stringBuffer.append(compoundIndexHashKeyToIndexNameMap.get(attributeQuery.getAttributeName()));
             } else {
                 stringBuffer.append(attributeQuery.getAttributeName());
@@ -226,5 +226,10 @@ public class ItemConfiguration {
 
     private String compoundName(final String propertyName, final String supportingPropertyName) {
         return propertyName + "_" + supportingPropertyName;
+    }
+
+    private boolean isAttributeHashOfACompoundIndexButDoesNotHaveANonCompoundIndexOnIt(final String attributeName) {
+        return compoundIndexHashKeyToIndexNameMap.keySet().contains(attributeName)
+                && !indexDefinitions.keySet().contains(attributeName);
     }
 }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/configuration/ItemConfiguration.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/configuration/ItemConfiguration.java
@@ -228,6 +228,19 @@ public class ItemConfiguration {
         return propertyName + "_" + supportingPropertyName;
     }
 
+    /*
+     * It is possible for a table to have an index defined on an attribute and a second index which is a compound index
+     * with the hash part of it the same attribute and the range some other attribute.
+     *
+     * This method returns true if there is an compound index with the hash part equal to a given attribute name and NOT
+     * another, non-compound index on the given attribute.
+     *
+     * This is to cater for the scenario where the range part of the compound key is optional which means that any items
+     * saved without the optional range value will not be copied to the table for that index. Any subsequent queries on
+     * that index which only supply the hash part will not return anything for matches where the range is not present.
+     * In this scenario, the query should be ran against the non-compound index on the attribute as they will include
+     * those items with the empty range value.
+     */
     private boolean isAttributeHashOfACompoundIndexButDoesNotHaveANonCompoundIndexOnIt(final String attributeName) {
         return compoundIndexHashKeyToIndexNameMap.keySet().contains(attributeName)
                 && !indexDefinitions.keySet().contains(attributeName);

--- a/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/database/configuration/ItemConfigurationTest.java
+++ b/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/database/configuration/ItemConfigurationTest.java
@@ -373,4 +373,28 @@ public class ItemConfigurationTest {
         // Then
         assertEquals("stringProperty_integerProperty_idx", indexNameForQuery);
     }
+
+    @Test
+    public void shouldGetIndexNameForQuery_withAttributeQueryAndCompoundIndexWithHashKeyEqualToAttributeNameAndNonCompoundIndexOnAttribute() {
+        // Given
+        final Class<? extends Item> itemClass = StubItem.class;
+        final String tableName = randomString(10);
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(itemClass, tableName);
+        final Collection<IndexDefinition> indexDefinitions = new ArrayList<>();
+        final String stringPropertyName = "stringProperty";
+        final String integerPropertyName = "integerProperty";
+        final CompoundIndexDefinition compoundIndexDefinition = new CompoundIndexDefinition(stringPropertyName,
+                integerPropertyName);
+        final IndexDefinition indexDefinition = new IndexDefinition(stringPropertyName);
+        indexDefinitions.add(compoundIndexDefinition);
+        indexDefinitions.add(indexDefinition);
+        itemConfiguration.registerIndexes(indexDefinitions);
+        final AttributeQuery attributeQuery = new AttributeQuery(stringPropertyName, mock(Condition.class));
+
+        // When
+        final String indexNameForQuery = itemConfiguration.indexNameForQuery(attributeQuery);
+
+        // Then
+        assertEquals("stringProperty_idx", indexNameForQuery);
+    }
 }


### PR DESCRIPTION
This fixes a bug where a table had an index defined on an attribute and a compound index where the attribute was the hash part of this compound index and the range part was an attribute that was optional.  When a non-compound attribute query was passed for the attribute in question, the compound index was being queried against.  This resulted in items which didn't contain the optional range part of the compound index to not be returned as they are not part of the compound index table.  This fix ensures that the non-compound index is queried against in this scenario.