### PR TITLE
Provide support for updating the name and email address of a MetricUser

### DIFF
--- a/cheddar/cheddar-metrics/build.gradle
+++ b/cheddar/cheddar-metrics/build.gradle
@@ -1,0 +1,5 @@
+apply from: '../../test.gradle'
+
+dependencies {
+    compile project(':commons:commons-lang')
+}

--- a/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
+++ b/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
@@ -22,8 +22,8 @@ public class MetricUser {
 
     private final String id;
     private final List<String> organisationIds;
-    private final String name;
-    private final String emailAddress;
+    private String name;
+    private String emailAddress;
     private final Map<String, Object> customAttributes;
 
     public MetricUser(final String id, final String organisationId, final String name, final String emailAddress) {
@@ -43,6 +43,14 @@ public class MetricUser {
         this.name = name;
         this.emailAddress = emailAddress;
         this.customAttributes = customAttributes;
+    }
+
+    public void updateName(final String name) {
+        this.name = name;
+    }
+
+    public void updateEmailAddress(final String emailAddress) {
+        this.emailAddress = emailAddress;
     }
 
     public String id() {

--- a/cheddar/cheddar-metrics/src/test/java/com/clicktravel/cheddar/metrics/MetricUserTest.java
+++ b/cheddar/cheddar-metrics/src/test/java/com/clicktravel/cheddar/metrics/MetricUserTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.metrics;
+
+import static com.clicktravel.common.random.Randoms.randomEmailAddress;
+import static com.clicktravel.common.random.Randoms.randomId;
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+@SuppressWarnings("unchecked")
+public class MetricUserTest {
+
+    @Test
+    public void shouldCreateMetricUser_withIdAndOrganisationIdAndNameAndEmailAddress() {
+        // Given
+        final String id = randomId();
+        final String organisationId = randomId();
+        final String name = randomString();
+        final String emailAddress = randomEmailAddress();
+
+        // When
+        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress);
+
+        // Then
+        assertEquals(id, metricUser.id());
+        assertEquals(organisationId, metricUser.organisationId());
+        assertEquals(1, metricUser.organisationIds().size());
+        assertEquals(organisationId, metricUser.organisationIds().get(0));
+        assertEquals(name, metricUser.name());
+        assertEquals(emailAddress, metricUser.emailAddress());
+        assertTrue(metricUser.customAttributes().isEmpty());
+    }
+
+    @Test
+    public void shouldCreateMetricUser_withIdAndOrganisationIdsAndNameAndEmailAddress() {
+        // Given
+        final String id = randomId();
+        final List<String> organisationIds = Arrays.asList(randomId(), randomId());
+        final String name = randomString();
+        final String emailAddress = randomEmailAddress();
+        final Map<String, Object> mockCustomAttributes = mock(Map.class);
+
+        // When
+        final MetricUser metricUser = new MetricUser(id, organisationIds, name, emailAddress, mockCustomAttributes);
+
+        // Then
+        assertEquals(id, metricUser.id());
+        assertEquals(organisationIds, metricUser.organisationIds());
+        assertEquals(name, metricUser.name());
+        assertEquals(emailAddress, metricUser.emailAddress());
+        assertEquals(mockCustomAttributes, metricUser.customAttributes());
+    }
+
+    @Test
+    public void shouldUpdateName_withName() {
+        // Given
+        final String id = randomId();
+        final String organisationId = randomId();
+        final String name = randomString();
+        final String emailAddress = randomEmailAddress();
+        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress);
+        final String newName = randomString();
+
+        // When
+        metricUser.updateName(newName);
+
+        // Then
+        assertEquals(newName, metricUser.name());
+    }
+
+    @Test
+    public void shouldUpdateEmailAddress_withEmailAddress() {
+        // Given
+        final String id = randomId();
+        final String organisationId = randomId();
+        final String name = randomString();
+        final String emailAddress = randomEmailAddress();
+        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress);
+        final String newEmailAddress = randomEmailAddress();
+
+        // When
+        metricUser.updateEmailAddress(newEmailAddress);
+
+        // Then
+        assertEquals(newEmailAddress, metricUser.emailAddress());
+    }
+}


### PR DESCRIPTION
- In order to allow consumers to update the name and email address of user they have created in metrics systems, the MetricUser needs to allow the values to be mutated.  This will allow the consumer to call these update methods and then actually call the method to update the metric user in the metric system.