### PR TITLE
API-126 add support to cheddar

### DIFF
--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/DefaultSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/DefaultSecurityContext.java
@@ -27,18 +27,22 @@ public class DefaultSecurityContext implements SecurityContext {
     private final Optional<String> teamId;
     private final Optional<String> agentUserId;
 
-    public DefaultSecurityContext(final String userId, final String teamId, final String agentUserId) {
+    private final Optional<String> appId;
+
+    public DefaultSecurityContext(final String userId, final String teamId, final String agentUserId,
+            final String appId) {
         this.userId = Optional.ofNullable(userId);
         this.teamId = Optional.ofNullable(teamId);
         this.agentUserId = Optional.ofNullable(agentUserId);
+        this.appId = Optional.ofNullable(appId);
     }
 
     public DefaultSecurityContext(final String userId, final String teamId) {
-        this(userId, teamId, null);
+        this(userId, teamId, null, null);
     }
 
     public DefaultSecurityContext(final String userId) {
-        this(userId, null, null);
+        this(userId, null, null, null);
     }
 
     @Override
@@ -60,5 +64,10 @@ public class DefaultSecurityContext implements SecurityContext {
     @Override
     public Optional<String> agentUserId() {
         return agentUserId;
+    }
+
+    @Override
+    public Optional<String> appId() {
+        return appId;
     }
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/NullSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/NullSecurityContext.java
@@ -48,4 +48,9 @@ public class NullSecurityContext implements SecurityContext {
         return Optional.empty();
     }
 
+    @Override
+    public Optional<String> appId() {
+        return Optional.empty();
+    }
+
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
@@ -54,7 +54,7 @@ public interface SecurityContext {
     Optional<String> agentUserId();
 
     /**
-     * @return Optional of the app ID in the security context. Used for pioneer apps
+     * @return Optional of the app ID in the security context.
      */
     Optional<String> appId();
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
@@ -52,4 +52,9 @@ public interface SecurityContext {
      *         against, see {@link #userId}
      */
     Optional<String> agentUserId();
+
+    /**
+     * @return Optional of the app ID in the security context. Used for pioneer apps
+     */
+    Optional<String> appId();
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
@@ -53,7 +53,7 @@ public class SecurityContextHolder {
         if (principal == null) {
             clear();
         } else {
-            set(new DefaultSecurityContext(principal, null, null));
+            set(new DefaultSecurityContext(principal, null, null, null));
         }
     }
 

--- a/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/DefaultSecurityContextTest.java
+++ b/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/DefaultSecurityContextTest.java
@@ -32,7 +32,8 @@ public class DefaultSecurityContextTest {
         final String userId = randomId();
         final String teamId = randomBoolean() ? null : randomId();
         final String agentUserId = randomBoolean() ? null : randomId();
-        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId);
+        final String appId = randomBoolean() ? null : randomId();
+        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId, appId);
 
         // When
         final Optional<String> returnedUserId = context.userId();
@@ -47,7 +48,8 @@ public class DefaultSecurityContextTest {
         final String userId = randomId();
         final String teamId = randomId();
         final String agentUserId = randomBoolean() ? null : randomId();
-        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId);
+        final String appId = randomBoolean() ? null : randomId();
+        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId, appId);
 
         // When
         final Optional<String> returnedTeamId = context.teamId();
@@ -62,7 +64,8 @@ public class DefaultSecurityContextTest {
         final String userId = randomId();
         final String teamId = randomBoolean() ? null : randomId();
         final String agentUserId = randomId();
-        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId);
+        final String appId = randomBoolean() ? null : randomId();
+        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId, appId);
 
         // When
         final Optional<String> returnedAgentUserId = context.agentUserId();
@@ -77,13 +80,30 @@ public class DefaultSecurityContextTest {
         final String userId = null;
         final String teamId = null;
         final String agentUserId = null;
-        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId);
+        final String appId = null;
+        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId, appId);
 
         // When
         final Optional<String> returnedUserId = context.userId();
 
         // Then
         assertEquals(Optional.empty(), returnedUserId);
+    }
+
+    @Test
+    public void shouldReturnAppId() {
+        // Given
+        final String userId = null;
+        final String teamId = null;
+        final String agentUserId = null;
+        final String appId = randomId();
+        final DefaultSecurityContext context = new DefaultSecurityContext(userId, teamId, agentUserId, appId);
+
+        // When
+        final Optional<String> returnedUserId = context.appId();
+
+        // Then
+        assertEquals(appId, returnedUserId.get());
     }
 
     @Test

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilter.java
@@ -39,6 +39,7 @@ public class ContainerSecurityRequestFilter implements ContainerRequestFilter {
     private static final String CLICK_PLATFORM_SCHEME = "clickplatform";
     private static final String CLICK_PLATFORM_AGENT_AUTHORIZATION_HEADER = "Agent-Authorization";
     private static final String CLICK_PLATFORM_TEAM_ID_HEADER = "Team-Id";
+    private static final String CLICK_PLATFORM_APP_ID_HEADER = "App-Id";
 
     @Override
     public void filter(final ContainerRequestContext requestContext) throws IOException {
@@ -47,7 +48,8 @@ public class ContainerSecurityRequestFilter implements ContainerRequestFilter {
         final String teamId = getValueForHeaderAndScheme(headers, CLICK_PLATFORM_TEAM_ID_HEADER, CLICK_PLATFORM_SCHEME);
         final String agentUserId = getValueForHeaderAndScheme(headers, CLICK_PLATFORM_AGENT_AUTHORIZATION_HEADER,
                 CLICK_PLATFORM_SCHEME);
-        SecurityContextHolder.set(new DefaultSecurityContext(userId, teamId, agentUserId));
+        final String appId = getValueForHeader(headers, CLICK_PLATFORM_APP_ID_HEADER);
+        SecurityContextHolder.set(new DefaultSecurityContext(userId, teamId, agentUserId, appId));
     }
 
     private String getValueForHeaderAndScheme(final MultivaluedMap<String, String> headers, final String header,
@@ -60,6 +62,15 @@ public class ContainerSecurityRequestFilter implements ContainerRequestFilter {
                         return headerValueParts[1];
                     }
                 }
+            }
+        }
+        return null;
+    }
+
+    private String getValueForHeader(final MultivaluedMap<String, String> headers, final String header) {
+        if (headers.containsKey(header)) {
+            for (final String headerValue : headers.get(header)) {
+                return headerValue;
             }
         }
         return null;


### PR DESCRIPTION
API-126 add support to cheddar to read the new app id header into the security context

Signed-off-by: Robin <robin.smith@clicktravel.com>