### PR TITLE
Add new message body writer to fix text/plain media type errors

### DIFF
--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/body/writer/ErrorResponseToTextPlainBodyWriter.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/body/writer/ErrorResponseToTextPlainBodyWriter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.rest.body.writer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import com.clicktravel.schema.canonical.data.model.v1.common.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Provider
+@Produces("text/plain")
+public class ErrorResponseToTextPlainBodyWriter implements MessageBodyWriter<ErrorResponse> {
+
+    private final ObjectMapper objectMapper;
+
+    public ErrorResponseToTextPlainBodyWriter() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations,
+            final MediaType mediaType) {
+        return type == ErrorResponse.class;
+    }
+
+    @Override
+    public long getSize(final ErrorResponse t, final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType) {
+        // deprecated by JAX-RS 2.0 and ignored by Jersey runtime
+        return 0;
+    }
+
+    @Override
+    public void writeTo(final ErrorResponse errorResponse, final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType, final MultivaluedMap<String, Object> httpHeaders,
+            final OutputStream entityStream) throws IOException, WebApplicationException {
+
+        final Writer writer = new PrintWriter(entityStream);
+        writer.write(objectMapper.writeValueAsString(errorResponse));
+        writer.flush();
+        writer.close();
+    }
+}

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/body/writer/ErrorResponseToTextPlainBodyWriter.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/body/writer/ErrorResponseToTextPlainBodyWriter.java
@@ -60,7 +60,6 @@ public class ErrorResponseToTextPlainBodyWriter implements MessageBodyWriter<Err
     public void writeTo(final ErrorResponse errorResponse, final Class<?> type, final Type genericType,
             final Annotation[] annotations, final MediaType mediaType, final MultivaluedMap<String, Object> httpHeaders,
             final OutputStream entityStream) throws IOException, WebApplicationException {
-
         final Writer writer = new PrintWriter(entityStream);
         writer.write(objectMapper.writeValueAsString(errorResponse));
         writer.flush();

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/ConstraintViolationExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/ConstraintViolationExceptionMapper.java
@@ -16,7 +16,6 @@
  */
 package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -25,12 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.clicktravel.cheddar.domain.model.exception.ConstraintViolationException;
-import com.clicktravel.cheddar.rest.media.MediaTypes;
 import com.clicktravel.schema.canonical.data.model.v1.common.Error;
 import com.clicktravel.schema.canonical.data.model.v1.common.ErrorResponse;
 
 @Provider
-@Produces(MediaTypes.CDM_V1_JSON)
 public class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/ContentMissingWebApplicationExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/ContentMissingWebApplicationExceptionMapper.java
@@ -16,20 +16,17 @@
  */
 package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import com.clicktravel.cheddar.rest.exception.ContentMissingWebApplicationException;
-import com.clicktravel.cheddar.rest.media.MediaTypes;
 import com.clicktravel.schema.canonical.data.model.v1.common.Error;
 import com.clicktravel.schema.canonical.data.model.v1.common.ErrorResponse;
 
 @Provider
-@Produces(MediaTypes.CDM_V1_JSON)
-public class ContentMissingWebApplicationExceptionMapper implements
-        ExceptionMapper<ContentMissingWebApplicationException> {
+public class ContentMissingWebApplicationExceptionMapper
+        implements ExceptionMapper<ContentMissingWebApplicationException> {
 
     @Override
     public Response toResponse(final ContentMissingWebApplicationException e) {

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonMappingExceptionMapper.java
@@ -19,7 +19,6 @@ package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;
 
 import javax.annotation.Priority;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -27,11 +26,9 @@ import javax.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.clicktravel.cheddar.rest.media.MediaTypes;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 @Provider
-@Produces(MediaTypes.CDM_V1_JSON)
 @Priority(Integer.MAX_VALUE)
 public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
 

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonParseExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonParseExceptionMapper.java
@@ -19,7 +19,6 @@ package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;
 
 import javax.annotation.Priority;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -27,11 +26,9 @@ import javax.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.clicktravel.cheddar.rest.media.MediaTypes;
 import com.fasterxml.jackson.core.JsonParseException;
 
 @Provider
-@Produces(MediaTypes.CDM_V1_JSON)
 @Priority(Integer.MAX_VALUE)
 public class JsonParseExceptionMapper implements ExceptionMapper<JsonParseException> {
 

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonProcessingExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/JsonProcessingExceptionMapper.java
@@ -19,7 +19,6 @@ package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 import static com.clicktravel.cheddar.rest.exception.mapper.cdm1.JsonProcessingExceptionMapperUtils.buildErrorResponse;
 
 import javax.annotation.Priority;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -27,11 +26,9 @@ import javax.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.clicktravel.cheddar.rest.media.MediaTypes;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 @Provider
-@Produces(MediaTypes.CDM_V1_JSON)
 @Priority(Integer.MAX_VALUE)
 public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
 

--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/ValidationExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/cdm1/ValidationExceptionMapper.java
@@ -16,18 +16,15 @@
  */
 package com.clicktravel.cheddar.rest.exception.mapper.cdm1;
 
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import com.clicktravel.cheddar.rest.media.MediaTypes;
 import com.clicktravel.common.validation.ValidationException;
 import com.clicktravel.schema.canonical.data.model.v1.common.ErrorResponse;
 import com.clicktravel.schema.canonical.data.model.v1.common.ValidationError;
 
 @Provider
-@Produces(MediaTypes.CDM_V1_JSON)
 public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
 
     @Override

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/config/RestResourceConfig.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/config/RestResourceConfig.java
@@ -58,7 +58,8 @@ public class RestResourceConfig extends ResourceConfig {
         register(ObjectMapperProvider.class);
         register(JacksonFeature.class);
         registerResources("com.clicktravel.cheddar.rest.exception.mapper", "com.clicktravel.cheddar.server.http.filter",
-                "com.clicktravel.cheddar.server.rest.resource.status", "com.clicktravel.services");
+                "com.clicktravel.cheddar.server.rest.resource.status", "com.clicktravel.services",
+                "com.clicktravel.cheddar.rest.body.writer");
         property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);
     }
 


### PR DESCRIPTION
When an endpoint was registering two or more media types in the @Produces annotation, if any were none json such as text/plain, and an error was thrown the mapping was attempting to return a json like object and failing. A new message body writer has been written to allow the correct entity type to be written back in the response. The @Produces annotation has also been removed from the exception mappers which allows the current ‘Accept’ed media type to be passed through. This further enables responses of any json based media types regardless of any specific media type defined on the endpoint.

Signed-off-by: James Butherway <james.butherway@clicktravel.com>