### PR TITLE
Start sending subject as an attribute in SNS

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sns/SnsTopicResource.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sns/SnsTopicResource.java
@@ -16,9 +16,13 @@
  */
 package com.clicktravel.infrastructure.messaging.aws.sns;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.policy.Policy;
 import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.SetTopicAttributesRequest;
 import com.amazonaws.services.sns.model.SubscribeRequest;
@@ -49,7 +53,12 @@ public class SnsTopicResource {
      * @throws AmazonClientException
      */
     public void publish(final String subject, final String message) throws AmazonClientException {
-        amazonSnsClient.publish(new PublishRequest().withTopicArn(topicArn).withSubject(subject).withMessage(message));
+        final Map<String, MessageAttributeValue> attributes = new HashMap<String, MessageAttributeValue>();
+        attributes.put("subject", new MessageAttributeValue().withStringValue(subject));
+
+        final PublishRequest request = new PublishRequest().withTopicArn(topicArn).withSubject(subject)
+                .withMessage(message).withMessageAttributes(attributes);
+        amazonSnsClient.publish(request);
     }
 
     /**

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/messaging/aws/sns/SnsTopicResourceTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/messaging/aws/sns/SnsTopicResourceTest.java
@@ -69,6 +69,7 @@ public class SnsTopicResourceTest {
         assertEquals(topicArn, publishRequest.getTopicArn());
         assertEquals(subject, publishRequest.getSubject());
         assertEquals(message, publishRequest.getMessage());
+        assertEquals(subject, publishRequest.getMessageAttributes().get("subject").getStringValue());
     }
 
     @Test
@@ -155,8 +156,8 @@ public class SnsTopicResourceTest {
         final Policy mockPolicy = mock(Policy.class);
         final String mockPolicyJson = randomString();
         when(mockPolicy.toJson()).thenReturn(mockPolicyJson);
-        doThrow(AmazonClientException.class).when(mockAmazonSnsClient).setTopicAttributes(
-                any(SetTopicAttributesRequest.class));
+        doThrow(AmazonClientException.class).when(mockAmazonSnsClient)
+                .setTopicAttributes(any(SetTopicAttributesRequest.class));
 
         // When
         AmazonClientException thrownException = null;


### PR DESCRIPTION
AWS SNS has started supporting filtering by attributes, as cheddar doesnt currently support attributes i would like to include the basic details of the subject as part of the attributes values.

This will allow basic filtering by subject

Signed-off-by: Robin <robin.smith@clicktravel.com>