### PR TITLE
Updated shutdown timeout in lifecycle controller to 65 seconds

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
@@ -37,7 +37,7 @@ public class ApplicationLifecycleController {
      * time must cover the completion of processing current REST requests. This time must also cover the maximum queue
      * poll time for message listeners and completion of processing for all messages already received.
      */
-    static final long SHUTDOWN_TIMEOUT_MILLIS = 60000; // = 60s
+    static final long SHUTDOWN_TIMEOUT_MILLIS = 65000; // = 65s
 
     private final RestServer restServer;
     private final MessageListener systemEventMessageListener;

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
@@ -37,7 +37,7 @@ public class ApplicationLifecycleController {
      * time must cover the completion of processing current REST requests. This time must also cover the maximum queue
      * poll time for message listeners and completion of processing for all messages already received.
      */
-    static final long SHUTDOWN_TIMEOUT_MILLIS = 50000; // = 50s
+    static final long SHUTDOWN_TIMEOUT_MILLIS = 60000; // = 60s
 
     private final RestServer restServer;
     private final MessageListener systemEventMessageListener;


### PR DESCRIPTION
We were finding that AWS long polling on certain resources such as message listeners needed 60 seconds instead of 50. Every so often an error was being thrown during deployment when shutdown occurred, stating that the thread had been killed while still processing. This should allow enough time for all threads to completed before the app is terminated.

Signed-off-by: James Butherway <james.butherway@clicktravel.com>