### PR TITLE
Allow apps to turn on rest rate limit logging

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/flow/control/FlowControlledRequestFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/flow/control/FlowControlledRequestFilter.java
@@ -41,7 +41,7 @@ import com.clicktravel.common.concurrent.RateLimiter;
 public class FlowControlledRequestFilter implements ContainerRequestFilter {
 
     @Autowired
-    @Value("${flow.control.rateLimitLogging:true}")
+    @Value("${flow.control.rateLimitLogging:false}")
     private boolean rateLimitLogging;
 
     private final Logger logger = Logger.getLogger(FlowControlledRequestFilter.class);

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/flow/control/FlowControlledRequestFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/flow/control/FlowControlledRequestFilter.java
@@ -25,7 +25,8 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.ext.Provider;
 
-import org.jboss.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -44,7 +45,7 @@ public class FlowControlledRequestFilter implements ContainerRequestFilter {
     @Value("${flow.control.rateLimitLogging:false}")
     private boolean rateLimitLogging;
 
-    private final Logger logger = Logger.getLogger(FlowControlledRequestFilter.class);
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final RateLimiter restRequestRateLimiter;
 


### PR DESCRIPTION
Simple logging will allow apps built on cheddar to log out the performance of the configured rate limiting per rest request handled

Signed-off-by: Robin <robin.smith@clicktravel.com>