### PR TITLE
Fixed company id mix up bug in intercom metric controller

### DIFF
--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
@@ -237,7 +237,7 @@ public class IntercomMetricCollector implements MetricCollector {
         final CompanyCollection companyCollection = user.getCompanyCollection();
         final List<String> companies = new ArrayList<>();
         while (companyCollection.hasNext()) {
-            companies.add(companyCollection.next().getId());
+            companies.add(companyCollection.next().getCompanyID());
         }
         return companies;
     }

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
@@ -300,22 +300,22 @@ public class IntercomMetricCollectorTest {
         final String userId = randomId();
         final Map<String, String> params = new HashMap<>();
         params.put("user_id", userId);
-        final User mockUser = randomIntercomUser();
-        when(User.find(params)).thenReturn(mockUser);
-        final Map<String, Object> mockCustomAttributes = mock(Map.class);
-        when(intercomToMetricMapper.apply(mockUser.getCustomAttributes())).thenReturn(mockCustomAttributes);
+        final User user = randomIntercomUser();
+        when(User.find(params)).thenReturn(user);
+        final Map<String, CustomAttribute> mockCustomAttributes = mock(Map.class);
+        user.setCustomAttributes(mockCustomAttributes);
 
         // When
         final MetricUser result = intercomMetricCollector.getUser(userId);
 
         // Then
         assertNotNull(result);
-        assertThat(result.id(), is(mockUser.getUserId()));
-        mockUser.getCompanyCollection().forEachRemaining(company -> {
-            assertTrue(result.organisationIds().contains(company.getId()));
+        assertThat(result.id(), is(user.getUserId()));
+        user.getCompanyCollection().getPage().forEach(company -> {
+            assertTrue(result.organisationIds().contains(company.getCompanyID()));
         });
-        assertThat(result.name(), is(mockUser.getName()));
-        assertThat(result.emailAddress(), is(mockUser.getEmail()));
+        assertThat(result.name(), is(user.getName()));
+        assertThat(result.emailAddress(), is(user.getEmail()));
         assertThat(result.customAttributes(), is(mockCustomAttributes));
     }
 

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/random/data/RandomIntercomDataGenerator.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/random/data/RandomIntercomDataGenerator.java
@@ -48,19 +48,19 @@ public class RandomIntercomDataGenerator {
 
     public static CompanyCollection randomCompanyCollection() {
         final List<Company> companies = new ArrayList<>();
-        final CompanyCollection companyCollection = mock(CompanyCollection.class);
         final int numberOfCompanies = randomIntInRange(1, 10);
 
         for (int i = 0; i < numberOfCompanies; i++) {
             final Company mockCompany = mock(Company.class);
+            final String id = randomId();
+            when(mockCompany.getId()).thenReturn(id);
             final String companyId = randomId();
             when(mockCompany.getCompanyID()).thenReturn(companyId);
 
             companies.add(mockCompany);
         }
 
-        when(companyCollection.getPage()).thenReturn(companies);
-        return companyCollection;
+        return new CompanyCollection(companies);
     }
 
     public static Map<String, CustomAttribute> randomCustomAttributes() {


### PR DESCRIPTION
When a user was being retreived from intercom its companies where being mapped to the id given by intercom and not the company id which is provided by the creator of the company. This fix should make sure that it is only known company_id’s that mapped back to a User when they are updated.

Signed-off-by: James Butherway <james.butherway@clicktravel.com>