### PR TITLE
Add system event handler to initiate application shutdown

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/host/aws/ec2/Ec2InstanceDataAccessor.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/host/aws/ec2/Ec2InstanceDataAccessor.java
@@ -38,7 +38,6 @@ public class Ec2InstanceDataAccessor implements Ec2InstanceData {
     @Override
     public String getInstanceId() {
         if (instanceId == null) {
-            logger.debug("About to retrieve EC2 instance id");
             instanceId = readMetadata("/instance-id");
             logger.debug("Retrieved EC2 instance id: [" + instanceId + "]");
         }

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationEC2InstanceTerminationRequestedEventHandler.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationEC2InstanceTerminationRequestedEventHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.server.application.lifecycle;
+
+import com.clicktravel.cheddar.system.event.ApplicationEC2InstanceTerminationRequestedEvent;
+import com.clicktravel.cheddar.system.event.SystemEvent;
+import com.clicktravel.cheddar.system.event.handler.AbstractSystemEventHandler;
+
+public class ApplicationEC2InstanceTerminationRequestedEventHandler extends AbstractSystemEventHandler {
+
+    private final String ec2InstanceId;
+    private final ApplicationLifecycleController applicationLifecycleController;
+
+    public ApplicationEC2InstanceTerminationRequestedEventHandler(final String ec2InstanceId,
+            final ApplicationLifecycleController applicationLifecycleController) {
+        super(null, null);
+        this.ec2InstanceId = ec2InstanceId;
+        this.applicationLifecycleController = applicationLifecycleController;
+    }
+
+    @Override
+    protected void handleSystemEvent(final SystemEvent event) {
+        final ApplicationEC2InstanceTerminationRequestedEvent systemEvent = (ApplicationEC2InstanceTerminationRequestedEvent) event;
+        if (ec2InstanceId.equals(systemEvent.getEc2InstanceId())) {
+            requestApplicationShutdown();
+        }
+    }
+
+    private void requestApplicationShutdown() {
+        new Thread(() -> {
+            logger.info(String.format(
+                    "Received event that EC2 instance %s is being terminated - Commencing graceful termination of Java process",
+                    ec2InstanceId));
+            applicationLifecycleController.shutdownApplication();
+            logger.info("Java process terminating");
+        }).start();
+    }
+
+    @Override
+    public Class<? extends SystemEvent> getEventClass() {
+        return ApplicationEC2InstanceTerminationRequestedEvent.class;
+    }
+
+}

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationEC2InstanceTerminationRequestedEventHandlerTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationEC2InstanceTerminationRequestedEventHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.server.application.lifecycle;
+
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.verifyNoMoreInteractions;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.clicktravel.cheddar.system.event.ApplicationEC2InstanceTerminationRequestedEvent;
+import com.clicktravel.cheddar.system.event.SystemEvent;
+
+public class ApplicationEC2InstanceTerminationRequestedEventHandlerTest {
+
+    private ApplicationEC2InstanceTerminationRequestedEventHandler handler;
+    private String ec2InstanceId;
+    private ApplicationLifecycleController mockApplicationLifecycleController;
+
+    @Before
+    public void setUp() {
+        ec2InstanceId = randomString();
+        mockApplicationLifecycleController = mock(ApplicationLifecycleController.class);
+        handler = new ApplicationEC2InstanceTerminationRequestedEventHandler(ec2InstanceId,
+                mockApplicationLifecycleController);
+    }
+
+    @Test
+    public void shouldRequestApplicationShutdown_withEventForEc2Instance() throws Exception {
+        // Given
+        final ApplicationEC2InstanceTerminationRequestedEvent event = new ApplicationEC2InstanceTerminationRequestedEvent();
+        event.setEc2InstanceId(ec2InstanceId);
+
+        // When
+        handler.handle(event);
+
+        // Then
+        Thread.sleep(100);
+        verify(mockApplicationLifecycleController).shutdownApplication();
+    }
+
+    @Test
+    public void shouldNotRequestApplicationShutdown_withEventForOtherEc2Instance() throws Exception {
+        // Given
+        final ApplicationEC2InstanceTerminationRequestedEvent event = new ApplicationEC2InstanceTerminationRequestedEvent();
+        event.setEc2InstanceId(randomString());
+
+        // When
+        handler.handle(event);
+
+        // Then
+        Thread.sleep(100);
+        verifyNoMoreInteractions(mockApplicationLifecycleController);
+    }
+
+    @Test
+    public void shouldReturnEventClass() {
+        // When
+        final Class<? extends SystemEvent> returnedClass = handler.getEventClass();
+
+        // Then
+        assertEquals(ApplicationEC2InstanceTerminationRequestedEvent.class, returnedClass);
+    }
+}


### PR DESCRIPTION
This adds a new system event handler which responds to `ApplicationEC2InstanceTerminationRequestedEvent` by initiating the Java application to shut down. The intent is to use this event as part of AWS Auto Scaling Group scale-in operations, allowing graceful shutdown of the application before the EC2 instance is terminated.