### PR TITLE
Add context to log messages from LoggingAspect

### DIFF
--- a/cheddar/cheddar-server/build.gradle
+++ b/cheddar/cheddar-server/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile project(':cheddar:cheddar-system-events')
     compile project(':cheddar:cheddar-features')
     compile project(':commons:commons-json-provider')
+    compile project(':cheddar:cheddar-context')
     
     compile "org.glassfish.jersey.ext:jersey-spring3:${jerseyVersion}"
     compile "org.glassfish.jersey.containers:jersey-container-grizzly2-http:${jerseyVersion}"
@@ -14,4 +15,7 @@ dependencies {
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'io.swagger:swagger-jersey2-jaxrs:1.5.8'
     compile "org.slf4j:jul-to-slf4j:${slf4jVersion}"
+
+    testRuntime "org.slf4j:slf4j-log4j12:${slf4jVersion}"
+    testRuntime 'log4j:log4j:1.2.17'
 }

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
@@ -22,6 +22,9 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.clicktravel.cheddar.request.context.SecurityContext;
+import com.clicktravel.cheddar.request.context.SecurityContextHolder;
+
 //@formatter:off
 /**
  * Aspect for automatically logging method calls. The methods to log are identified by a {@code @Pointcut} definition.
@@ -54,16 +57,17 @@ public abstract class LoggingAspect {
 
     private Object proceedAndLog(final ProceedingJoinPoint point) throws Throwable {
         final String methodCallDetail = methodCallDetail(point);
+        final String securityContextDetail = securityContextDetail();
         final long startTime = System.currentTimeMillis();
         try {
-            logger.debug("Entering method call; call:[{}]", methodCallDetail);
+            logger.debug("Entering method call; call:[{}] {}", methodCallDetail, securityContextDetail);
             final Object result = point.proceed();
-            logger.debug("Method call returned; call:[{}] return:[{}] timeMillis:[{}]", methodCallDetail, result,
-                    System.currentTimeMillis() - startTime);
+            logger.debug("Method call returned; call:[{}] return:[{}] timeMillis:[{}] {}", methodCallDetail, result,
+                    System.currentTimeMillis() - startTime, securityContextDetail);
             return result;
         } catch (final Throwable e) {
-            logger.debug("Method call exception; call:[{}] exception:[{}] timeMillis:[{}]", methodCallDetail, e,
-                    System.currentTimeMillis() - startTime);
+            logger.debug("Method call exception; call:[{}] exception:[{}] timeMillis:[{}] {}", methodCallDetail, e,
+                    System.currentTimeMillis() - startTime, securityContextDetail);
             throw e;
         }
     }
@@ -83,6 +87,17 @@ public abstract class LoggingAspect {
             sb.append(arg == null ? "null" : arg.toString());
         }
         sb.append(')');
+        return sb.toString();
+    }
+
+    private String securityContextDetail() {
+        final StringBuilder sb = new StringBuilder();
+        final SecurityContext securityContext = SecurityContextHolder.get();
+        sb.append("principal:[");
+        sb.append(securityContext.userId().orElse("null"));
+        sb.append("] team:[");
+        sb.append(securityContext.teamId().orElse("null"));
+        sb.append("]");
         return sb.toString();
     }
 }

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/configuration/ApplicationConfigurationTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/configuration/ApplicationConfigurationTest.java
@@ -20,8 +20,11 @@ import static com.clicktravel.common.random.Randoms.randomString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import org.junit.Test;
+
 public class ApplicationConfigurationTest {
 
+    @Test
     public void shouldCreateApplicationConfiguration_withNameAndVersionandFrameworkVersion() throws Exception {
         // Given
         final String name = randomString(10);

--- a/cheddar/cheddar-server/src/test/resources/log4j.xml
+++ b/cheddar/cheddar-server/src/test/resources/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
+<log4j:configuration debug="true">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{ABSOLUTE}  %60.60c:%-5.5L %-4.4X{context} %-5.5p %m%n" />
+        </layout>
+    </appender>
+    <logger name="com.clicktravel" additivity="false">
+        <level value="debug" />
+        <appender-ref ref="console" />
+    </logger>
+    <root>
+        <priority value="warn" />
+        <appender-ref ref="console" />
+    </root>
+</log4j:configuration>


### PR DESCRIPTION
This change adds logging of the principal id and team id for HTTP requests and responses to/from the server application.