### PR TITLE
Add option to set number of Grizzly worker threads

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
@@ -52,14 +52,14 @@ public class ApplicationLifecycleController {
         this.messageListeners = messageListeners;
     }
 
-    public void startApplication(final int servicePort, final int statusPort, final String bindAddress)
-            throws IOException {
+    public void startApplication(final int servicePort, final int statusPort, final String bindAddress,
+            final int workerThreads) throws IOException {
         logger.info("Starting application");
         logger.info("Starting system event message listener");
         systemEventMessageListener.start();
         logger.info("Starting remaining message listeners");
         messageListenersExcept(systemEventMessageListener).stream().forEach(MessageListener::start);
-        restServer.start(servicePort, statusPort, bindAddress);
+        restServer.start(servicePort, statusPort, bindAddress, workerThreads);
         logger.info("Application started");
     }
 

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
@@ -27,6 +27,11 @@ import com.clicktravel.cheddar.server.application.lifecycle.ApplicationLifecycle
 
 public class RestApplication {
 
+    private static final String DEFAULT_CONTEXT = "UNKNOWN";
+    private static final int DEFAULT_SERVICE_PORT = 8080;
+    private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0";
+    private static final String DEFAULT_WORKER_THREADS = "16";
+
     /**
      * Starts the RestServer to listen on the given port and address combination
      *
@@ -42,10 +47,11 @@ public class RestApplication {
      * @throws Exception
      */
     public static void main(final String... args) {
-        final String context = args.length > 0 ? args[0] : "UNKNOWN";
-        final int servicePort = args.length > 1 ? Integer.parseInt(args[1]) : 8080;
+        final String context = args.length > 0 ? args[0] : DEFAULT_CONTEXT;
+        final int servicePort = args.length > 1 ? Integer.parseInt(args[1]) : DEFAULT_SERVICE_PORT;
         final int statusPort = args.length > 2 ? Integer.parseInt(args[2]) : servicePort + 100;
-        final String bindAddress = args.length > 3 ? args[3] : "0.0.0.0";
+        final String bindAddress = args.length > 3 ? args[3] : DEFAULT_BIND_ADDRESS;
+        final int workerThreads = Integer.parseInt(System.getProperty("worker.threads", DEFAULT_WORKER_THREADS));
         MDC.put("context", context);
         MDC.put("hostId", System.getProperty("host.id", "UNKNOWN"));
         SLF4JBridgeHandler.removeHandlersForRootLogger();
@@ -67,7 +73,7 @@ public class RestApplication {
                 applicationLifecycleController.shutdownApplication();
                 logger.info("Java process terminating");
             }));
-            applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress);
+            applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress, workerThreads);
             Thread.currentThread().join();
         } catch (final InterruptedException e) {
             logger.info("Java process interrupted");

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleControllerTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleControllerTest.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-
 package com.clicktravel.cheddar.server.application.lifecycle;
 
 import static com.clicktravel.cheddar.server.application.lifecycle.ApplicationLifecycleController.SHUTDOWN_TIMEOUT_MILLIS;
@@ -35,6 +34,7 @@ import org.mockito.InOrder;
 
 import com.clicktravel.cheddar.infrastructure.messaging.MessageListener;
 import com.clicktravel.cheddar.server.rest.RestServer;
+import com.clicktravel.common.random.Randoms;
 
 public class ApplicationLifecycleControllerTest {
 
@@ -66,16 +66,17 @@ public class ApplicationLifecycleControllerTest {
         final int servicePort = randomInt(16384);
         final int statusPort = randomInt(16384);
         final String bindAddress = randomString();
+        final int workerThreads = Randoms.randomIntInRange(2, 16);
 
         // When
-        applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress);
+        applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress, workerThreads);
 
         // Then
         final InOrder inOrder = inOrder(mockRestServer, mockSystemEventMessageListener, mockOtherMessageListener);
         inOrder.verify(mockSystemEventMessageListener).start();
         inOrder.verify(mockOtherMessageListener).start();
         verifyNoMoreInteractions(mockSystemEventMessageListener, mockOtherMessageListener);
-        inOrder.verify(mockRestServer).start(servicePort, statusPort, bindAddress);
+        inOrder.verify(mockRestServer).start(servicePort, statusPort, bindAddress, workerThreads);
     }
 
     @Test


### PR DESCRIPTION
This change adds an option `-Dworker.threads` to set the number of Grizzly worker threads. This defaults to 16.