### PR TITLE
Make "process tracker complete" log message consistent with the "process tracker started" log message

### DIFF
--- a/cheddar/cheddar-persisted-trackers/src/main/java/com/clicktravel/cheddar/application/tracker/PersistedTracker.java
+++ b/cheddar/cheddar-persisted-trackers/src/main/java/com/clicktravel/cheddar/application/tracker/PersistedTracker.java
@@ -59,7 +59,7 @@ public class PersistedTracker<T1 extends Process, T2 extends Item> implements Tr
     public void completeProcess(final T1 process) {
         final T2 processItem = processToItemMapper.map(process);
         databaseTemplate.delete(processItem);
-        logger.info("ProcessTracker ended with process: " + processItem);
+        logger.info("ProcessTracker ended with id: " + process.processId().id());
     }
 
     @Override


### PR DESCRIPTION
- When a tracked process is started we see the "ProcessTracker started with id: <id>" message in the log.  However, on completion a log message which attempts to log the tracked process item out is written.  This doesn't contain a toString implementation so all we see is the object reference.  This change makes sure we see the "ProcessTracker ended with id: <id>" message to enable us to tie up the start and end of tracked processes.