### PR TITLE
Remove distinct port for /status endpoints

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleController.java
@@ -52,14 +52,14 @@ public class ApplicationLifecycleController {
         this.messageListeners = messageListeners;
     }
 
-    public void startApplication(final int servicePort, final int statusPort, final String bindAddress,
-            final int workerThreads) throws IOException {
+    public void startApplication(final int servicePort, final String bindAddress, final int workerThreads)
+            throws IOException {
         logger.info("Starting application");
         logger.info("Starting system event message listener");
         systemEventMessageListener.start();
         logger.info("Starting remaining message listeners");
         messageListenersExcept(systemEventMessageListener).stream().forEach(MessageListener::start);
-        restServer.start(servicePort, statusPort, bindAddress, workerThreads);
+        restServer.start(servicePort, bindAddress, workerThreads);
         logger.info("Application started");
     }
 

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
@@ -42,8 +42,6 @@ import io.swagger.models.Info;
  */
 public class RestServer {
 
-    private static final int STATUS_WORKER_THREADS = 2;
-
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ResourceConfig resourceConfig;
     private HttpServer httpServer;
@@ -52,17 +50,13 @@ public class RestServer {
         this.resourceConfig = resourceConfig;
     }
 
-    public void start(final int servicePort, final int statusPort, final String bindAddress, final int workerThreads)
-            throws IOException {
+    public void start(final int servicePort, final String bindAddress, final int workerThreads) throws IOException {
         final URI baseUri = UriBuilder.fromUri("http://" + bindAddress).port(servicePort).build();
         logger.info("Configuring REST server on: " + baseUri.toString());
         httpServer = GrizzlyHttpServerFactory.createHttpServer(baseUri, resourceConfig, false);
         enableAutoGenerationOfSwaggerSpecification();
         configureWorkerThreadPool(httpServer.getListener("grizzly"), workerThreads);
-        final NetworkListener statusPortListener = new NetworkListener("status", baseUri.getHost(), statusPort);
-        configureWorkerThreadPool(statusPortListener, STATUS_WORKER_THREADS);
-        httpServer.addListener(statusPortListener);
-        logger.info("Starting REST server; servicePort:[" + servicePort + "] statusPort:[" + statusPort + "]");
+        logger.info("Starting REST server; servicePort:[" + servicePort + "]");
         httpServer.start();
     }
 

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
@@ -39,8 +39,7 @@ public class RestApplication {
      *            <ul>
      *            <li>{@code context} - Name of application, defaults to {@code UNKNOWN}</li>
      *            <li>{@code service-port} - Port number for REST service endpoints, defaults to {@code 8080}</li>
-     *            <li>{@code status-port} - Port number for REST status endpoints ({@code /status} and
-     *            {@code /status/healthCheck}), defaults to {@code service-port + 100}</li>
+     *            <li>{@code status-port} - unused</li>
      *            <li>{@code bind-address} - Local IP address to bind server to, defaults to {@code 0.0.0.0}</li>
      *            </ul>
      *
@@ -49,7 +48,6 @@ public class RestApplication {
     public static void main(final String... args) {
         final String context = args.length > 0 ? args[0] : DEFAULT_CONTEXT;
         final int servicePort = args.length > 1 ? Integer.parseInt(args[1]) : DEFAULT_SERVICE_PORT;
-        final int statusPort = args.length > 2 ? Integer.parseInt(args[2]) : servicePort + 100;
         final String bindAddress = args.length > 3 ? args[3] : DEFAULT_BIND_ADDRESS;
         final int workerThreads = Integer.parseInt(System.getProperty("worker.threads", DEFAULT_WORKER_THREADS));
         MDC.put("context", context);
@@ -73,7 +71,7 @@ public class RestApplication {
                 applicationLifecycleController.shutdownApplication();
                 logger.info("Java process terminating");
             }));
-            applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress, workerThreads);
+            applicationLifecycleController.startApplication(servicePort, bindAddress, workerThreads);
             Thread.currentThread().join();
         } catch (final InterruptedException e) {
             logger.info("Java process interrupted");

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleControllerTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/application/lifecycle/ApplicationLifecycleControllerTest.java
@@ -64,19 +64,18 @@ public class ApplicationLifecycleControllerTest {
     public void shouldStartApplication_withServicePortStatusPortAndBindAddress() throws Exception {
         // Given
         final int servicePort = randomInt(16384);
-        final int statusPort = randomInt(16384);
         final String bindAddress = randomString();
         final int workerThreads = Randoms.randomIntInRange(2, 16);
 
         // When
-        applicationLifecycleController.startApplication(servicePort, statusPort, bindAddress, workerThreads);
+        applicationLifecycleController.startApplication(servicePort, bindAddress, workerThreads);
 
         // Then
         final InOrder inOrder = inOrder(mockRestServer, mockSystemEventMessageListener, mockOtherMessageListener);
         inOrder.verify(mockSystemEventMessageListener).start();
         inOrder.verify(mockOtherMessageListener).start();
         verifyNoMoreInteractions(mockSystemEventMessageListener, mockOtherMessageListener);
-        inOrder.verify(mockRestServer).start(servicePort, statusPort, bindAddress, workerThreads);
+        inOrder.verify(mockRestServer).start(servicePort, bindAddress, workerThreads);
     }
 
     @Test


### PR DESCRIPTION
Status reports and health checks are to be served on the same port as other HTTP requests.