### PR TITLE
Updated slf4j version to newest stable build

### DIFF
--- a/cheddar/cheddar-server/build.gradle
+++ b/cheddar/cheddar-server/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile 'io.swagger:swagger-jersey2-jaxrs:1.5.8'
     compile "org.slf4j:jul-to-slf4j:${slf4jVersion}"
 
-    testRuntime "org.slf4j:slf4j-log4j12:${slf4jVersion}"
-    testRuntime 'log4j:log4j:1.2.17'
+    testRuntime 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
+    testRuntime 'org.apache.logging.log4j:log4j-api:2.11.1'
+    testRuntime 'org.apache.logging.log4j:log4j-core:2.11.1'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ jerseyVersion=2.22.2
 jodaTimeVersion=2.10
 junitVersion=4.12
 powermockVersion=1.6.5
-slf4jVersion=1.7.21
+slf4jVersion=1.7.25
 springVersion=4.1.1.RELEASE


### PR DESCRIPTION
Also added the newest version of log4j in the test runtime dependacies to bring them uptodate with the services that now ue log4j 2.