### PR TITLE
Throw a MetricException if an error is encountered when trying to tag a company in Intercom

### DIFF
--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
@@ -89,7 +89,8 @@ public class IntercomMetricCollector implements MetricCollector {
         try {
             Tag.tag(new Tag().setName(tagName), new Company().setCompanyID(metricOrganisation.id()));
         } catch (final Exception e) {
-            logger.warn("Error tagging Intercom organisation: {} - {} ", metricOrganisation, e.getMessage());
+            throw new MetricException(
+                    String.format("Error tagging Intercom organisation: %s - %s ", metricOrganisation, e.getMessage()));
         }
     }
 

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollectorTest.java
@@ -135,6 +135,26 @@ public class IntercomMetricCollectorTest {
     }
 
     @Test
+    public void shouldNotTagIntercomOrganisation_withExceptionThrownDuringTagging() throws Exception {
+        // Given
+        final String tagName = randomString();
+        final MetricOrganisation metricOrganisation = randomMetricOrganisation();
+
+        when(Tag.tag(any(Tag.class), any(Company.class))).thenThrow(Exception.class);
+
+        // When
+        MetricException thrownException = null;
+        try {
+            intercomMetricCollector.tagOrganisation(tagName, metricOrganisation);
+        } catch (final MetricException e) {
+            thrownException = e;
+        }
+
+        // Then
+        assertNotNull(thrownException);
+    }
+
+    @Test
     public void shouldCreateUser_withMetricUser() throws Exception {
         // Given
         final MetricUser metricUser = randomMetricUser();


### PR DESCRIPTION
- This allows API clients to handle errors as they wish rather than the underlying error being hidden by simply logging it out