### PR TITLE
Clarify correct version of JAX-RS API is used

### DIFF
--- a/cheddar/cheddar-rest/build.gradle
+++ b/cheddar/cheddar-rest/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':cheddar:cheddar-domain')
     compile project(':cheddar:cheddar-application')
 
-    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    compile "javax.ws.rs:javax.ws.rs-api:${javaxRsApiVersion}"
     compile 'javax.inject:javax.inject:1'
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}"

--- a/commons/commons-json-provider/build.gradle
+++ b/commons/commons-json-provider/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:${jerseyVersion}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:${jacksonVersion}"
     runtime "joda-time:joda-time:${jodaTimeVersion}"
-    compile "javax.ws.rs:javax.ws.rs-api:2.0.1"
+    compile "javax.ws.rs:javax.ws.rs-api:${javaxRsApiVersion}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ awsJavaSdkVersion=1.11.409
 hamcrestVersion=1.3
 jacksonVersion=2.7.4
 jerseyVersion=2.27
+javaxRsApiVersion=2.1
 jodaTimeVersion=2.10
 junitVersion=4.12
 powermockVersion=1.6.5


### PR DESCRIPTION
JAX-RS API version 2.1 is the compile dependency of Jersey 2.27. This change just clarifies the selection of this version (rather than JAX-RS API version 2.0.1)