### PR TITLE
Ensure consistent version of Jackson is used

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 awsJavaSdkVersion=1.11.409
 hamcrestVersion=1.3
-jacksonVersion=2.7.4
+jacksonVersion=2.9.6
 jerseyVersion=2.27
 javaxRsApiVersion=2.1
 jodaTimeVersion=2.10


### PR DESCRIPTION
`io.intercom:intercom-java:2.8.0` depends on a more recent version of Jackson. This change ensures a consistent version of Jackson is listed as a dependency of Cheddar (sub)projects.