### PR TITLE
Reduce fixed text in some logging

### DIFF
--- a/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/EventMessageHandler.java
+++ b/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/EventMessageHandler.java
@@ -43,12 +43,12 @@ public class EventMessageHandler<E extends Event> implements MessageHandler<Type
             final String messageType = typedMessage.getType();
             final Set<EventHandler<E>> eventHandlersForType = eventHandlers.get(messageType);
             if (eventHandlersForType.isEmpty()) {
-                logger.debug("No handlers for received event " + messageType);
+                logger.debug("No handlers for event " + messageType);
             }
             for (final EventHandler<E> eventHandler : eventHandlersForType) {
                 try {
                     final E event = AbstractEvent.newEvent(eventHandler.getEventClass(), typedMessage.getPayload());
-                    logger.debug("Handling received event; " + event);
+                    logger.debug("Handling; " + event);
                     if (!eventHandler.getEventClass().isAssignableFrom(event.getClass())) {
                         throw new IllegalStateException("Event of type " + event.getClass() + " is not compatible with "
                                 + eventHandler.getEventClass() + " in event handler");

--- a/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/EventPublisher.java
+++ b/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/EventPublisher.java
@@ -33,7 +33,7 @@ public abstract class EventPublisher<E extends Event> {
     }
 
     public void publishEvent(final E event) {
-        logger.debug("Publishing event: " + event);
+        logger.debug("Publishing: " + event);
         final TypedMessage typedMessage = new SimpleMessage(event.type(), event.serialize());
         messagePublisher.publish(typedMessage);
     }

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
@@ -60,13 +60,13 @@ public abstract class LoggingAspect {
         final String securityContextDetail = securityContextDetail();
         final long startTime = System.currentTimeMillis();
         try {
-            logger.debug("Entering method call; call:[{}] {}", methodCallDetail, securityContextDetail);
+            logger.debug("Enter;[{}] {}", methodCallDetail, securityContextDetail);
             final Object result = point.proceed();
-            logger.debug("Method call returned; call:[{}] return:[{}] timeMillis:[{}] {}", methodCallDetail, result,
-                    System.currentTimeMillis() - startTime, securityContextDetail);
+            logger.debug("Return;[{}] ms:[{}] {}", result, System.currentTimeMillis() - startTime,
+                    securityContextDetail);
             return result;
         } catch (final Throwable e) {
-            logger.debug("Method call exception; call:[{}] exception:[{}] timeMillis:[{}] {}", methodCallDetail, e,
+            logger.debug("Exception;[{}] exception:[{}] ms:[{}] {}", methodCallDetail, e,
                     System.currentTimeMillis() - startTime, securityContextDetail);
             throw e;
         }

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
@@ -62,12 +62,10 @@ public abstract class LoggingAspect {
         try {
             logger.debug("Enter;[{}] {}", methodCallDetail, securityContextDetail);
             final Object result = point.proceed();
-            logger.debug("Return;[{}] ms:[{}] {}", result, System.currentTimeMillis() - startTime,
-                    securityContextDetail);
+            logger.debug("Return;[{}] ms:[{}]", result, System.currentTimeMillis() - startTime);
             return result;
         } catch (final Throwable e) {
-            logger.debug("Exception;[{}] exception:[{}] ms:[{}] {}", methodCallDetail, e,
-                    System.currentTimeMillis() - startTime, securityContextDetail);
+            logger.debug("Exception;[{}] ms:[{}]", e, System.currentTimeMillis() - startTime);
             throw e;
         }
     }


### PR DESCRIPTION
In particular the amount of logging in th logging aspect has been removed to focus mainly on the dynamic data working under the assumption that the class name will be in the logging pattern making it clear this is a logging aspect log

The largest change is that the return call no longer logs the methodCallDetail as that is duplication of the details on the enter log, following on logs can be obtained by finding the enter log by thread id which is assumed to also be in your log pattern

Signed-off-by: Robin <robin.smith@clicktravel.com>