### PR TITLE
Adding back in method name to exit statement

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
@@ -62,7 +62,9 @@ public abstract class LoggingAspect {
         try {
             logger.debug("Enter;[{}] {}", methodCallDetail, securityContextDetail);
             final Object result = point.proceed();
-            logger.debug("Return;[{}] ms:[{}]", result, System.currentTimeMillis() - startTime);
+            logger.debug("Exit; [{}] returned [{}] ms:[{}]",
+                    ((MethodSignature) (point.getSignature())).getMethod().getName(), result,
+                    System.currentTimeMillis() - startTime);
             return result;
         } catch (final Throwable e) {
             logger.debug("Exception;[{}] ms:[{}]", e, System.currentTimeMillis() - startTime);


### PR DESCRIPTION
Feedback has suggested that while the reduction of all input details is good that having at least the method name is helpful when debugging return values.

Signed-off-by: Robin <robin.smith@clicktravel.com>