### PR TITLE
Removed support for publishing Swagger and WADL files from cheddar services

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
@@ -54,7 +54,8 @@ public class RestServer {
         final URI baseUri = UriBuilder.fromUri("http://" + bindAddress).port(servicePort).build();
         logger.info("Configuring REST server on: " + baseUri.toString());
         httpServer = GrizzlyHttpServerFactory.createHttpServer(baseUri, resourceConfig, false);
-        enableAutoGenerationOfSwaggerSpecification();
+        // The auto generation of Swagger specification has been temporarily remove for security reasons
+        // enableAutoGenerationOfSwaggerSpecification();
         configureWorkerThreadPool(httpServer.getListener("grizzly"), workerThreads);
         logger.info("Starting REST server; servicePort:[" + servicePort + "]");
         httpServer.start();

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/config/RestResourceConfig.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/config/RestResourceConfig.java
@@ -61,6 +61,7 @@ public class RestResourceConfig extends ResourceConfig {
                 "com.clicktravel.cheddar.server.rest.resource.status", "com.clicktravel.services",
                 "com.clicktravel.cheddar.rest.body.writer");
         property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);
+        property(ServerProperties.WADL_FEATURE_DISABLE, true);
     }
 
     private void registerResources(final String... packages) {


### PR DESCRIPTION
During testing it was found that we no longer want to support automatically publishing a cheddar service’s documentation via swagger or application.wadl files that one may have had access to with the correct level of authentication.