### PR TITLE
Turned auto generated swagger back on for Grizzly apps

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
@@ -54,8 +54,7 @@ public class RestServer {
         final URI baseUri = UriBuilder.fromUri("http://" + bindAddress).port(servicePort).build();
         logger.info("Configuring REST server on: " + baseUri.toString());
         httpServer = GrizzlyHttpServerFactory.createHttpServer(baseUri, resourceConfig, false);
-        // The auto generation of Swagger specification has been temporarily remove for security reasons
-        // enableAutoGenerationOfSwaggerSpecification();
+        enableAutoGenerationOfSwaggerSpecification();
         configureWorkerThreadPool(httpServer.getListener("grizzly"), workerThreads);
         logger.info("Starting REST server; servicePort:[" + servicePort + "]");
         httpServer.start();


### PR DESCRIPTION
This change was turned off in this PR for the last round of pentest (https://github.com/travel-cloud/Cheddar/commit/bfd934a41fafb50b3b4cfe5b01b435266ff98c33). We still don’t want the wadl to be generated but this should allow us to easily get the newest swagger specifications for our core Grizzly/Java applications. The security issue will be fixed using infrastructure shortly.