### PR TITLE
Add utility methods for logging as JSON

### DIFF
--- a/commons/commons-logging/build.gradle
+++ b/commons/commons-logging/build.gradle
@@ -1,3 +1,4 @@
+apply from: '../../test.gradle'
 apply from: '../../logging-api.gradle'
 
 dependencies {

--- a/commons/commons-logging/build.gradle
+++ b/commons/commons-logging/build.gradle
@@ -1,0 +1,5 @@
+apply from: '../../logging-api.gradle'
+
+dependencies {
+    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+}

--- a/commons/commons-logging/src/main/java/com/clicktravel/common/logging/JsonLog.java
+++ b/commons/commons-logging/src/main/java/com/clicktravel/common/logging/JsonLog.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.common.logging;
+
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility for logging messages as JSON rather than plain strings.
+ *
+ * Example usage:
+ *
+ * <pre>
+ * {@code
+ * private final Logger log = LoggerFactory.getLogger(getClass());
+ *
+ * ... {
+ *
+ *     Map<String,Object> message = new HashMap<>();
+ *     Map<String,Object> userDetail = new HashMap<>();
+ *
+ *     userDetail.put("id", "9182-abf");
+ *     userDetail.put("firstName", "Bob");
+ *     message.put("eventType", "logInSuccess");
+ *     message.put("user", userDetail);
+ *
+ *     JsonLog.info(logger, message);
+ * }}
+ * </pre>
+ */
+public class JsonLog {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static String asJson(final Object message) {
+        try {
+            return mapper.writeValueAsString(message);
+        } catch (final JsonProcessingException e) {
+            throw new RuntimeException("Could not serialise log message to JSON", e);
+        }
+    }
+
+    /**
+     * Log a message as JSON at TRACE level
+     * @param logger Logger to write message to
+     * @param message Message to be serialised to JSON and written to log
+     */
+    public static void trace(final Logger logger, final Object message) {
+        logger.trace(asJson(message));
+    }
+
+    /**
+     * Log a message as JSON at DEBUG level
+     * @param logger Logger to write message to
+     * @param message Message to be serialised to JSON and written to log
+     */
+    public static void debug(final Logger logger, final Object message) {
+        logger.debug(asJson(message));
+    }
+
+    /**
+     * Log a message as JSON at INFO level
+     * @param logger Logger to write message to
+     * @param message Message to be serialised to JSON and written to log
+     */
+    public static void info(final Logger logger, final Object message) {
+        logger.info(asJson(message));
+    }
+
+    /**
+     * Log a message as JSON at WARN level
+     * @param logger Logger to write message to
+     * @param message Message to be serialised to JSON and written to log
+     */
+    public static void warn(final Logger logger, final Object message) {
+        logger.warn(asJson(message));
+    }
+
+    /**
+     * Log a message as JSON at ERROR level
+     * @param logger Logger to write message to
+     * @param message Message to be serialised to JSON and written to log
+     */
+    public static void error(final Logger logger, final Object message) {
+        logger.error(asJson(message));
+    }
+
+}

--- a/commons/commons-logging/src/main/java/com/clicktravel/common/logging/JsonLog.java
+++ b/commons/commons-logging/src/main/java/com/clicktravel/common/logging/JsonLog.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * <pre>
  * {@code
- * private final Logger log = LoggerFactory.getLogger(getClass());
+ * private final Logger logger = LoggerFactory.getLogger(getClass());
  *
  * ... {
  *

--- a/commons/commons-logging/src/test/java/com/clicktravel/common/logging/JsonLogTest.java
+++ b/commons/commons-logging/src/test/java/com/clicktravel/common/logging/JsonLogTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.common.logging;
+
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SuppressWarnings("unchecked")
+public class JsonLogTest {
+
+    private Logger logger;
+    private ObjectMapper mapper;
+
+    @Before
+    public void setUp() {
+        logger = mock(Logger.class);
+        mapper = new ObjectMapper();
+    }
+
+    private Map<String, Object> randomMessage() {
+        final Map<String, Object> message = new HashMap<>();
+        message.put(randomString(), randomString());
+        return message;
+    }
+
+    private void assertExpectedJson(final Map<String, Object> expectedMap, final String actualJson) throws Exception {
+        final Map<String, Object> actualMap = mapper.readValue(actualJson, Map.class);
+        assertEquals(expectedMap, actualMap);
+    }
+
+    @Test
+    public void shouldLogTraceJson_withLoggerAndMessage() throws Exception {
+        // Given
+        final Map<String, Object> message = randomMessage();
+
+        // When
+        JsonLog.trace(logger, message);
+
+        // Then
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger).trace(captor.capture());
+        assertExpectedJson(message, captor.getValue());
+    }
+
+    @Test
+    public void shouldLogDebugJson_withLoggerAndMessage() throws Exception {
+        // Given
+        final Map<String, Object> message = randomMessage();
+
+        // When
+        JsonLog.debug(logger, message);
+
+        // Then
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger).debug(captor.capture());
+        assertExpectedJson(message, captor.getValue());
+    }
+
+    @Test
+    public void shouldLogInfoJson_withLoggerAndMessage() throws Exception {
+        // Given
+        final Map<String, Object> message = randomMessage();
+
+        // When
+        JsonLog.info(logger, message);
+
+        // Then
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger).info(captor.capture());
+        assertExpectedJson(message, captor.getValue());
+    }
+
+    @Test
+    public void shouldLogWarnJson_withLoggerAndMessage() throws Exception {
+        // Given
+        final Map<String, Object> message = randomMessage();
+
+        // When
+        JsonLog.warn(logger, message);
+
+        // Then
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger).warn(captor.capture());
+        assertExpectedJson(message, captor.getValue());
+    }
+
+    @Test
+    public void shouldLogErrorJson_withLoggerAndMessage() throws Exception {
+        // Given
+        final Map<String, Object> message = randomMessage();
+
+        // When
+        JsonLog.error(logger, message);
+
+        // Then
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger).error(captor.capture());
+        assertExpectedJson(message, captor.getValue());
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ include (
     "commons:commons-httpclient",
     "commons:commons-json-provider",
     "commons:commons-test",
+    "commons:commons-logging",
     
     "cheddar:cheddar-metrics",
     "cheddar:cheddar-metrics-intercom",


### PR DESCRIPTION
This change adds simple methods for logging messages as JSON rather than plain strings, using SLF4J and Jackson’s `ObjectMapper`.