### PR TITLE
Added AWS XRay support to CHEDDAR

### DIFF
--- a/cheddar/cheddar-context/build.gradle
+++ b/cheddar/cheddar-context/build.gradle
@@ -8,4 +8,6 @@ dependencies {
     compile "org.springframework:spring-context-support:${springVersion}"
     compile "org.springframework:spring-web:${springVersion}"
     compile "org.springframework:spring-aop:${springVersion}"
+    compile "com.amazonaws:aws-xray-recorder-sdk-core:2.9.0"
+    compile "com.amazonaws:aws-xray-recorder-sdk-aws-sdk:2.9.0"
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AWSXraySegmentContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AWSXraySegmentContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.request.context;
+
+import java.util.Optional;
+
+import com.amazonaws.xray.entities.Segment;
+
+/**
+ * Interface to implement when you wish to stores the AWS XRay Segment context.
+ */
+public interface AWSXraySegmentContext {
+
+    Optional<Segment> requestSegment();
+
+}

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AWSXraySegmentContextHolder.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AWSXraySegmentContextHolder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.request.context;
+
+import java.util.Optional;
+
+import com.amazonaws.xray.entities.Segment;
+
+/**
+ * Retains the current XRay segment for the request if one has been set. This needed because 
+ * the standard AWSXRayServletFilter is not compatible with CHEDDAR so it needs to be 
+ * manually created, stored and closed for each request.
+ */
+public class AWSXraySegmentContextHolder {
+
+    private final static ThreadLocal<AWSXraySegmentContext> REQUEST_CONTEXT = new ThreadLocal<AWSXraySegmentContext>() {
+    };
+
+    public static void set(final AWSXraySegmentContext awsXraySegmentContext) {
+        REQUEST_CONTEXT.set(awsXraySegmentContext);
+    }
+
+    public static AWSXraySegmentContext get() {
+        final AWSXraySegmentContext awsXraySegmentContext = REQUEST_CONTEXT.get();
+        return awsXraySegmentContext == null ? NullAWSXraySegmentContext.NULL : awsXraySegmentContext;
+    }
+
+    public static void clear() {
+        REQUEST_CONTEXT.remove();
+    }
+    
+     private static class NullAWSXraySegmentContext implements AWSXraySegmentContext {
+
+        private static NullAWSXraySegmentContext NULL = new NullAWSXraySegmentContext();
+
+        private NullAWSXraySegmentContext() {
+        }
+
+        @Override
+        public Optional<Segment> requestSegment() {
+            return Optional.empty();
+        }
+
+      
+    }
+
+}

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/DefaultAWSXraySegmentContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/DefaultAWSXraySegmentContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.request.context;
+
+import java.util.Optional;
+
+import com.amazonaws.xray.entities.Segment;
+
+/**
+ * Default implementation which stores the AWS XRay Segment context.
+ */
+public class DefaultAWSXraySegmentContext implements AWSXraySegmentContext {
+
+    private final Optional<Segment> requestSegment;
+  
+    public DefaultAWSXraySegmentContext(final Segment requestSegment) {
+        this.requestSegment = Optional.ofNullable(requestSegment);
+    }
+
+    @Override
+    public Optional<Segment> requestSegment() {
+        return requestSegment;
+    }
+}

--- a/cheddar/cheddar-integration-aws/build.gradle
+++ b/cheddar/cheddar-integration-aws/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile project(':commons:commons-httpclient')
     compile project(':cheddar:cheddar-messaging')
     compile project(':cheddar:cheddar-persistence')
+    compile project(':cheddar:cheddar-context')
 
     compile "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-dynamodb:${awsJavaSdkVersion}"
@@ -17,6 +18,10 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-lambda:${awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-cloudformation:${awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-ssm:${awsJavaSdkVersion}"
+    compile "com.amazonaws:aws-xray-recorder-sdk-core:2.9.0"
+    compile "com.amazonaws:aws-xray-recorder-sdk-aws-sdk:2.9.0"
+
+    
     compile "org.springframework:spring-context-support:${springVersion}"
     compile "org.springframework:spring-aop:${springVersion}"
 

--- a/cheddar/cheddar-server/build.gradle
+++ b/cheddar/cheddar-server/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile project(':cheddar:cheddar-features')
     compile project(':commons:commons-json-provider')
     compile project(':cheddar:cheddar-context')
+    compile project(':cheddar:cheddar-integration-aws')
     
     compile "org.glassfish.jersey.ext:jersey-spring4:${jerseyVersion}"
     compile "org.glassfish.jersey.containers:jersey-container-grizzly2-http:${jerseyVersion}"

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/aws/AWSXrayRequestFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/aws/AWSXrayRequestFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.server.http.filter.aws;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Segment;
+import com.clicktravel.cheddar.request.context.AWSXraySegmentContextHolder;
+import com.clicktravel.cheddar.request.context.DefaultAWSXraySegmentContext;
+
+/**
+ *  Filter used to create an AWS XRay segment for each HTTP request. This then allows
+ *  any instrumented AWS clients to automatically add sub segments to this segment which 
+ *  will show up in the AWS console for that environment.
+ */
+@Provider
+@Priority(Priorities.USER)
+public class AWSXrayRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        final Segment segment = AWSXRay.beginSegment("Starting request segment for:" + requestContext.getUriInfo().getPath());
+        AWSXraySegmentContextHolder.set(new DefaultAWSXraySegmentContext(segment));
+    }
+
+}

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/aws/AWSXrayResponseFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/aws/AWSXrayResponseFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.server.http.filter.aws;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Segment;
+import com.clicktravel.cheddar.request.context.AWSXraySegmentContextHolder;
+
+/**
+ *  The response filter that will be called at the end of each HTTP response for all services.
+ *  If there is an open AWS XRay segment in the context holder it will grab it and close it 
+ *  then clear down the context holder for this thread.
+ */
+@Provider
+@Priority(Priorities.USER)
+public class AWSXrayResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(final ContainerRequestContext requestContext, final ContainerResponseContext responseContext)
+            throws IOException {
+        if(AWSXraySegmentContextHolder.get().requestSegment().isPresent()) {
+            final Segment requestSegment = AWSXraySegmentContextHolder.get().requestSegment().get();
+            AWSXRay.getGlobalRecorder().setTraceEntity(requestSegment);
+            AWSXRay.endSegment();
+        }
+        AWSXraySegmentContextHolder.clear();
+    }
+}

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/application/RestApplication.java
@@ -23,6 +23,9 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
+import com.amazonaws.xray.strategy.IgnoreErrorContextMissingStrategy;
 import com.clicktravel.cheddar.server.application.lifecycle.ApplicationLifecycleController;
 
 public class RestApplication {
@@ -60,6 +63,9 @@ public class RestApplication {
             logger.info(String.format("java.version:[%s] java.vendor:[%s] maxMemoryMb:[%d]",
                     System.getProperty("java.version"), System.getProperty("java.vendor"),
                     Runtime.getRuntime().maxMemory() / (1024 * 1024)));
+            // Make sure AWS XRay missing segments don't cause runtime exceptions during start up
+            AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder.standard().withContextMissingStrategy(new IgnoreErrorContextMissingStrategy());
+            AWSXRay.setGlobalRecorder(builder.build());
             @SuppressWarnings("resource")
             final ConfigurableApplicationContext applicationContext = new ClassPathXmlApplicationContext(
                     "applicationContext.xml");


### PR DESCRIPTION
This adds AWS Xray support by manually creating a new segment on each request, storing it in local storage and closing as the response is returned to calling client.

When a segment is open and the AWS clients have been manually instrumented in the service you get output similar to that of what we see in the node projects.

If we are happy with this after letting it soak UAT with Wire (PR coming next) we can look into how to have this only turned on in production.