### PR TITLE
Updated CHEDDAR XRay segment names to API request: {Method} {Path}

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/aws/AWSXrayRequestFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/aws/AWSXrayRequestFilter.java
@@ -17,6 +17,7 @@
 package com.clicktravel.cheddar.server.http.filter.aws;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
@@ -24,24 +25,58 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.ext.Provider;
 
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.uri.UriTemplate;
+
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Segment;
 import com.clicktravel.cheddar.request.context.AWSXraySegmentContextHolder;
 import com.clicktravel.cheddar.request.context.DefaultAWSXraySegmentContext;
 
 /**
- *  Filter used to create an AWS XRay segment for each HTTP request. This then allows
- *  any instrumented AWS clients to automatically add sub segments to this segment which 
- *  will show up in the AWS console for that environment.
+ * Filter used to create an AWS XRay segment for each HTTP request. This then allows any instrumented AWS clients to
+ * automatically add sub segments to this segment which will show up in the AWS console for that environment.
  */
 @Provider
 @Priority(Priorities.USER)
 public class AWSXrayRequestFilter implements ContainerRequestFilter {
 
     @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
-        final Segment segment = AWSXRay.beginSegment("Starting request segment for:" + requestContext.getUriInfo().getPath());
+    public void filter(final ContainerRequestContext requestContext) throws IOException {
+        String segmentName;
+        if (requestContext.getUriInfo() instanceof ExtendedUriInfo) {
+            segmentName = getPathWithTemplateParamsNotValues(requestContext.getMethod(),
+                    (ExtendedUriInfo) requestContext.getUriInfo());
+        } else {
+            // This is in case we ever swap the ContainerRequestFilter strategy
+            // and ExtendedUriInfo is no longer returned with getUriInfo()
+            segmentName = requestContext.getMethod() + " " + requestContext.getUriInfo().getPath();
+        }
+        final Segment segment = AWSXRay.beginSegment(segmentName);
         AWSXraySegmentContextHolder.set(new DefaultAWSXraySegmentContext(segment));
+    }
+
+    /**
+     * In order to better group the XRay segments we would like name them after the request's path without its template
+     * params substituted for the real values and no braces e.g GET wire/id/queue.
+     *
+     * @param requestMethod the string verb used for the request e.g. POST
+     * @param requestUriInfo for the current request
+     * @return A String that represents the path with template params.
+     */
+    private String getPathWithTemplateParamsNotValues(final String requestMethod,
+            final ExtendedUriInfo requestUriInfo) {
+        final List<UriTemplate> matchedTemplates = requestUriInfo.getMatchedTemplates();
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append(requestMethod);
+        builder.append(" ");
+
+        for (int i = matchedTemplates.size() - 1; i >= 0; i--) {
+            builder.append(matchedTemplates.get(i).getTemplate().replaceAll("\\{", "").replaceAll("\\}", ""));
+        }
+
+        return builder.toString();
     }
 
 }


### PR DESCRIPTION
This change adds a segment name building method that uses the request context to get the path with the templates unsubstitted so that we can name the XRay segments more genrically to allow for sample grouping.