### PR TITLE
[CREW-6712] Update MetricUser to support phone number

### DIFF
--- a/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
+++ b/cheddar/cheddar-metrics-intercom/src/main/java/com/clicktravel/cheddar/metrics/intercom/IntercomMetricCollector.java
@@ -224,7 +224,7 @@ public class IntercomMetricCollector implements MetricCollector {
             throw new MetricUserNotFoundException(userId);
         } else {
             return new MetricUser(intercomUser.getUserId(), getUserOrganisations(intercomUser), intercomUser.getName(),
-                    intercomUser.getEmail(), getCustomAttributes(intercomUser));
+                    intercomUser.getEmail(), intercomUser.getPhone(), getCustomAttributes(intercomUser));
         }
 
     }
@@ -252,6 +252,7 @@ public class IntercomMetricCollector implements MetricCollector {
         intercomUser.setId(user.id());
         intercomUser.setUserId(user.id());
         intercomUser.setName(user.name());
+        intercomUser.setPhone(user.phoneNumber());
         intercomUser.setCustomAttributes(metricToIntercomCustomAttributeMapper.apply(user.customAttributes()));
         if (!Equals.isNullOrBlank(user.emailAddress())) {
             intercomUser.setEmail(user.emailAddress());

--- a/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/random/data/RandomMetricDataGenerator.java
+++ b/cheddar/cheddar-metrics-intercom/src/test/java/com/clicktravel/cheddar/metrics/intercom/random/data/RandomMetricDataGenerator.java
@@ -53,7 +53,7 @@ public class RandomMetricDataGenerator {
         for (int i = 0; i < numberOfOrganisations; i++) {
             organisationIds.add(randomId());
         }
-        return new MetricUser(randomId(), organisationIds, randomString(), randomEmailAddress(),
+        return new MetricUser(randomId(), organisationIds, randomString(), randomEmailAddress(), randomPhoneNumber(),
                 randomMetricCustomAttributes());
     }
 

--- a/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
+++ b/cheddar/cheddar-metrics/src/main/java/com/clicktravel/cheddar/metrics/MetricUser.java
@@ -24,24 +24,27 @@ public class MetricUser {
     private final List<String> organisationIds;
     private String name;
     private String emailAddress;
+    private String phoneNumber;
     private final Map<String, Object> customAttributes;
 
-    public MetricUser(final String id, final String organisationId, final String name, final String emailAddress) {
+    public MetricUser(final String id, final String organisationId, final String name, final String emailAddress, final String phoneNumber) {
         super();
         this.id = id;
         organisationIds = organisationId != null ? Arrays.asList(organisationId) : new ArrayList<>();
         this.name = name;
         this.emailAddress = emailAddress;
+        this.phoneNumber = phoneNumber;
         customAttributes = new HashMap<>();
     }
 
     public MetricUser(final String id, final List<String> organisationIds, final String name, final String emailAddress,
-            final Map<String, Object> customAttributes) {
+            final String phoneNumber, final Map<String, Object> customAttributes) {
         super();
         this.id = id;
         this.organisationIds = organisationIds;
         this.name = name;
         this.emailAddress = emailAddress;
+        this.phoneNumber = phoneNumber;
         this.customAttributes = customAttributes;
     }
 
@@ -51,6 +54,10 @@ public class MetricUser {
 
     public void updateEmailAddress(final String emailAddress) {
         this.emailAddress = emailAddress;
+    }
+
+    public void updatePhoneNumber(final String phoneNumber) {
+        this.phoneNumber = phoneNumber;
     }
 
     public String id() {
@@ -71,6 +78,10 @@ public class MetricUser {
 
     public String emailAddress() {
         return emailAddress;
+    }
+
+    public String phoneNumber() {
+        return phoneNumber;
     }
 
     public Map<String, Object> customAttributes() {

--- a/cheddar/cheddar-metrics/src/test/java/com/clicktravel/cheddar/metrics/MetricUserTest.java
+++ b/cheddar/cheddar-metrics/src/test/java/com/clicktravel/cheddar/metrics/MetricUserTest.java
@@ -16,9 +16,7 @@
  */
 package com.clicktravel.cheddar.metrics;
 
-import static com.clicktravel.common.random.Randoms.randomEmailAddress;
-import static com.clicktravel.common.random.Randoms.randomId;
-import static com.clicktravel.common.random.Randoms.randomString;
+import static com.clicktravel.common.random.Randoms.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -39,9 +37,10 @@ public class MetricUserTest {
         final String organisationId = randomId();
         final String name = randomString();
         final String emailAddress = randomEmailAddress();
+        final String phoneNumber = randomPhoneNumber();
 
         // When
-        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress);
+        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress, phoneNumber);
 
         // Then
         assertEquals(id, metricUser.id());
@@ -50,6 +49,7 @@ public class MetricUserTest {
         assertEquals(organisationId, metricUser.organisationIds().get(0));
         assertEquals(name, metricUser.name());
         assertEquals(emailAddress, metricUser.emailAddress());
+        assertEquals(phoneNumber, metricUser.phoneNumber());
         assertTrue(metricUser.customAttributes().isEmpty());
     }
 
@@ -60,16 +60,18 @@ public class MetricUserTest {
         final List<String> organisationIds = Arrays.asList(randomId(), randomId());
         final String name = randomString();
         final String emailAddress = randomEmailAddress();
+        final String phoneNumber = randomPhoneNumber();
         final Map<String, Object> mockCustomAttributes = mock(Map.class);
 
         // When
-        final MetricUser metricUser = new MetricUser(id, organisationIds, name, emailAddress, mockCustomAttributes);
+        final MetricUser metricUser = new MetricUser(id, organisationIds, name, emailAddress, phoneNumber, mockCustomAttributes);
 
         // Then
         assertEquals(id, metricUser.id());
         assertEquals(organisationIds, metricUser.organisationIds());
         assertEquals(name, metricUser.name());
         assertEquals(emailAddress, metricUser.emailAddress());
+        assertEquals(phoneNumber, metricUser.phoneNumber());
         assertEquals(mockCustomAttributes, metricUser.customAttributes());
     }
 
@@ -80,7 +82,8 @@ public class MetricUserTest {
         final String organisationId = randomId();
         final String name = randomString();
         final String emailAddress = randomEmailAddress();
-        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress);
+        final String phoneNumber = randomPhoneNumber();
+        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress, phoneNumber);
         final String newName = randomString();
 
         // When
@@ -97,7 +100,8 @@ public class MetricUserTest {
         final String organisationId = randomId();
         final String name = randomString();
         final String emailAddress = randomEmailAddress();
-        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress);
+        final String phoneNumber = randomPhoneNumber();
+        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress, phoneNumber);
         final String newEmailAddress = randomEmailAddress();
 
         // When
@@ -105,5 +109,23 @@ public class MetricUserTest {
 
         // Then
         assertEquals(newEmailAddress, metricUser.emailAddress());
+    }
+
+    @Test
+    public void shouldUpdatePhoneNumber_withPhoneNumber() {
+        // Given
+        final String id = randomId();
+        final String organisationId = randomId();
+        final String name = randomString();
+        final String emailAddress = randomEmailAddress();
+        final String phoneNumber = randomPhoneNumber();
+        final MetricUser metricUser = new MetricUser(id, organisationId, name, emailAddress, phoneNumber);
+        final String newPhoneNumber = randomPhoneNumber();
+
+        // When
+        metricUser.updatePhoneNumber(newPhoneNumber);
+
+        // Then
+        assertEquals(newPhoneNumber, metricUser.phoneNumber());
     }
 }


### PR DESCRIPTION
- We want to synchronise phone numbers in intercom with phone numbers in the platform
- The users service already uses the MetricUser and IntercomMetricCollector to synchronise data to Intercom so extend it to include the phone number