### PR TITLE
[CREW-6852] - Ensure ConfidentialString can be built from Json

### DIFF
--- a/commons/commons-lang/build.gradle
+++ b/commons/commons-lang/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile "joda-time:joda-time:${jodaTimeVersion}"
     compile 'javax.mail:mail:1.4.7'
+    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
     testCompile "junit:junit:${junitVersion}"
     testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/commons/commons-lang/src/main/java/com/clicktravel/common/security/ConfidentialString.java
+++ b/commons/commons-lang/src/main/java/com/clicktravel/common/security/ConfidentialString.java
@@ -16,6 +16,9 @@
  */
 package com.clicktravel.common.security;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Holds a {@link String} that has confidential information which should not be casually displayed. {@link #toString()}
  * is defined to not include the confidential information.
@@ -24,7 +27,8 @@ public class ConfidentialString {
 
     private final String string;
 
-    public ConfidentialString(final String string) {
+    @JsonCreator
+    public ConfidentialString(@JsonProperty("string") final String string) {
         this.string = string;
     }
 


### PR DESCRIPTION
- The object doesn't have a default constructor or public setter so was failing to be created from Json.
- The added Json attributes should ensure that it can be created from Json