### PR TITLE
CREW-7414 Turn on reading unknown enums as null.

### DIFF
--- a/commons/commons-json-provider/src/main/java/com/clicktravel/common/http/application/ObjectMapperProvider.java
+++ b/commons/commons-json-provider/src/main/java/com/clicktravel/common/http/application/ObjectMapperProvider.java
@@ -36,6 +36,7 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.setSerializationInclusion(Include.NON_NULL);
+        objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
 
         // Swagger codegen generates the following code, but it seems to be redundant
         // as the Java model files for enums have @JsonValue on the toString() methods


### PR DESCRIPTION
- Turning this on to avoid the choas the resulting InvalidFormatException causes when an unknown enum is read.