### PR TITLE
[CREW-8296] Add ExceptionMapper to catch URISyntaxException

### DIFF
--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/URISyntaxExceptionMapper.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/exception/mapper/URISyntaxExceptionMapper.java
@@ -1,0 +1,23 @@
+package com.clicktravel.cheddar.rest.exception.mapper;
+
+import java.net.URISyntaxException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class URISyntaxExceptionMapper implements ExceptionMapper<URISyntaxException> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Response toResponse(final URISyntaxException exception) {
+        if (logger.isDebugEnabled()) {
+            logger.debug(exception.getMessage());
+        }
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+}


### PR DESCRIPTION
- This will prevent URISyntaxExceptions from returning a full stack trace exposing internal details of the system