### PR TITLE
[CREW-8296] - Add request filter to Cheddar to return a structured error message if an invalid query string is appended to a URL

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/query/QueryParameterValidationFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/query/QueryParameterValidationFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.clicktravel.cheddar.server.http.filter.query;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter used to return a standard error in the case that an invalid query string is provided to a URL. Previously we
+ * were outputting a HTML page with a stack trace on which is a security breach due to it exposing information about
+ * libraries and frameworks we use.
+ */
+@Provider
+@Priority(Priorities.USER)
+public class QueryParameterValidationFilter implements ContainerRequestFilter {
+
+    final Logger logger = LoggerFactory.getLogger(QueryParameterValidationFilter.class);
+
+    @Override
+    public void filter(final ContainerRequestContext requestContext) throws IOException {
+        final String query = requestContext.getUriInfo().getRequestUri().getQuery();
+
+        if (query != null && query.equals("q=\"")) {
+            logger.debug("Invalid query string parameter provided to {}", requestContext.getUriInfo().getPath());
+
+            final String errorJson = "{\"error\": \"Invalid query parameter\", \"details\": \"Invalid query string parameter provided.\"}";
+
+            requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST).entity(errorJson)
+                    .type(MediaType.APPLICATION_JSON).build());
+        }
+
+    }
+
+}


### PR DESCRIPTION
- Previously, when a query string such as q=" was appended to a URL, this caused a Grizzly error to be thrown which resulted in a HTML page with a stack trace.  This is not a good thing for security as it exposes frameworks and libraries that we use.
- This change adds a request filter which checks for the invalid query string and returns a HTTP 400 if it is invalid.