### PR TITLE
[CREW-8296] - Add custom error page for Grizzly application to Cheddar

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/RestServer.java
@@ -54,6 +54,15 @@ public class RestServer {
         final URI baseUri = UriBuilder.fromUri("http://" + bindAddress).port(servicePort).build();
         logger.info("Configuring REST server on: " + baseUri.toString());
         httpServer = GrizzlyHttpServerFactory.createHttpServer(baseUri, resourceConfig, false);
+
+        httpServer.getServerConfiguration()
+                .setDefaultErrorPageGenerator((request, status, reasonPhrase, description, exception) -> {
+                    logger.debug("Grizzly error thrown.  Status: {}; Reason: {}; Description: {}; Exception: {}",
+                            status, reasonPhrase, description, exception.getClass().getCanonicalName());
+
+                    return "<html><body><h1>Error processing request</h1><p>Apologies, there was an error processing your request. Please try again.</p></body></html>";
+                });
+
         enableAutoGenerationOfSwaggerSpecification();
         configureWorkerThreadPool(httpServer.getListener("grizzly"), workerThreads);
         logger.info("Starting REST server; servicePort:[" + servicePort + "]");


### PR DESCRIPTION
- It looks like this is needed in order to not display the default error which contains the stack trace.
- The previous attempt to add a filter has not worked as it looks like the filters are at the Jersey server level which the processing for comes after the base Grizzly processing.
- The error being thrown is directly from Grizzly.
- Once I've tested and this does what we want, I may refine the error page.