### PR TITLE
[CREW-8979] Add New Sanitiser Method to Cheddar

### DIFF
--- a/commons/commons-lang/src/main/java/com/clicktravel/common/security/Sanitiser.java
+++ b/commons/commons-lang/src/main/java/com/clicktravel/common/security/Sanitiser.java
@@ -33,7 +33,7 @@ public class Sanitiser {
 
     public static String sanitiseValue(final String value) {
         if (StringUtils.isBlank(value)) {
-            return null;
+            return value;
         }
 
         String sanitisedString = value.trim();
@@ -59,7 +59,7 @@ public class Sanitiser {
      */
     public static String sanitiseIfMarkupPresent(final String value) {
         if (StringUtils.isBlank(value)) {
-            return null;
+            return value;
         }
 
         String sanitisedString = value.trim();

--- a/commons/commons-lang/src/test/java/com/clicktravel/common/security/SanitiserTest.java
+++ b/commons/commons-lang/src/test/java/com/clicktravel/common/security/SanitiserTest.java
@@ -92,7 +92,6 @@ public class SanitiserTest {
         assertEquals("O'Test", sanitisedValue);
     }
 
-    // Below tests for sanitiseIfMarkupPresent method
     @Test
     public void shouldNotSanitise_whenNoMarkUp() {
         // Given
@@ -106,7 +105,7 @@ public class SanitiserTest {
     }
 
     @Test
-    public void shouldNotSanitise_whenContainsAmpersand() {
+    public void shouldNotSanitiseWhenContainsAmpersand_whenNoMarkUp() {
         // Given
         final String value = "Miles & Miles";
 
@@ -118,7 +117,7 @@ public class SanitiserTest {
     }
 
     @Test
-    public void shouldSanitiseIfMarkUpPresent_withValueHavingXSSAttackPrevented() {
+    public void shouldSanitiseWithValueHavingXSSAttackPrevented_ifMarkUpPresent() {
         // Given
         final String value = "<a href='https://www.example.com/' onclick='alert(\"XSS Attack\")'>Click Me</a>";
 
@@ -130,7 +129,7 @@ public class SanitiserTest {
     }
 
     @Test
-    public void shouldSanitiseIfNoMarkupPresent_multipleSuspectCharacters() {
+    public void shouldSanitiseWithMultipleSuspectCharacters_whenNoMarkUp() {
         // Given
         final String value = randomString(10);
 

--- a/commons/commons-lang/src/test/java/com/clicktravel/common/security/SanitiserTest.java
+++ b/commons/commons-lang/src/test/java/com/clicktravel/common/security/SanitiserTest.java
@@ -93,7 +93,7 @@ public class SanitiserTest {
     }
 
     @Test
-    public void shouldNotSanitise_whenNoMarkUp() {
+    public void shouldNotSanitiseIfMarkupPresent_whenNoMarkUp() {
         // Given
         final String value = randomString(10);
 
@@ -105,7 +105,7 @@ public class SanitiserTest {
     }
 
     @Test
-    public void shouldNotSanitiseWhenContainsAmpersand_whenNoMarkUp() {
+    public void shouldNotSanitiseIfMarkupPresentWhenContainsAmpersand_whenNoMarkUp() {
         // Given
         final String value = "Miles & Miles";
 
@@ -117,7 +117,7 @@ public class SanitiserTest {
     }
 
     @Test
-    public void shouldSanitiseWithValueHavingXSSAttackPrevented_ifMarkUpPresent() {
+    public void shouldSanitiseIfMarkupPresent_withValueHavingXSSAttackPrevented() {
         // Given
         final String value = "<a href='https://www.example.com/' onclick='alert(\"XSS Attack\")'>Click Me</a>";
 
@@ -129,7 +129,7 @@ public class SanitiserTest {
     }
 
     @Test
-    public void shouldSanitiseWithMultipleSuspectCharacters_whenNoMarkUp() {
+    public void shouldSanitiseIfMarkupPresentWithMultipleSuspectCharacters_whenNoMarkUp() {
         // Given
         final String value = randomString(10);
 

--- a/commons/commons-lang/src/test/java/com/clicktravel/common/security/SanitiserTest.java
+++ b/commons/commons-lang/src/test/java/com/clicktravel/common/security/SanitiserTest.java
@@ -91,4 +91,53 @@ public class SanitiserTest {
         // Then
         assertEquals("O'Test", sanitisedValue);
     }
+
+    // Below tests for sanitiseIfMarkupPresent method
+    @Test
+    public void shouldNotSanitise_whenNoMarkUp() {
+        // Given
+        final String value = randomString(10);
+
+        // When
+        final String sanitisedValue = Sanitiser.sanitiseIfMarkupPresent(value);
+
+        // Then
+        assertEquals(value, sanitisedValue);
+    }
+
+    @Test
+    public void shouldNotSanitise_whenContainsAmpersand() {
+        // Given
+        final String value = "Miles & Miles";
+
+        // When
+        final String sanitisedValue = Sanitiser.sanitiseIfMarkupPresent(value);
+
+        // Then
+        assertEquals(value, sanitisedValue);
+    }
+
+    @Test
+    public void shouldSanitiseIfMarkUpPresent_withValueHavingXSSAttackPrevented() {
+        // Given
+        final String value = "<a href='https://www.example.com/' onclick='alert(\"XSS Attack\")'>Click Me</a>";
+
+        // When
+        final String sanitisedValue = Sanitiser.sanitiseIfMarkupPresent(value);
+
+        // Then
+        assertEquals("Click Me", sanitisedValue);
+    }
+
+    @Test
+    public void shouldSanitiseIfNoMarkupPresent_multipleSuspectCharacters() {
+        // Given
+        final String value = randomString(10);
+
+        // When
+        final String sanitisedValue = Sanitiser.sanitiseIfMarkupPresent("==" + value);
+
+        // Then
+        assertEquals(value, sanitisedValue);
+    }
 }


### PR DESCRIPTION
- the current sanitiser method in cheddar not quite right for what we want to use it for… currently it will sanitise and encode which means that some names will come back encoded if they include things like ‘&’. Which isn’t what we want for this
- new method will only sanitise when the input actually looks like HTML or markup
- new tests added